### PR TITLE
Remove all deprecated functionality (i.e. version 1.0!)

### DIFF
--- a/lib/benchee.ex
+++ b/lib/benchee.ex
@@ -23,37 +23,24 @@ for {module, moduledoc} <- [{Benchee, elixir_doc}, {:benchee, erlang_doc}] do
     Run benchmark jobs defined by a map and optionally provide configuration
     options.
 
-    Runs the given benchmarks and prints the results on the console.
-
-    * jobs - a map from descriptive benchmark job name to a function to be
-    executed and benchmarked
-    * configuration - configuration options to alter what Benchee does, see
-    `Benchee.Configuration.init/1` for documentation of the available options.
+    Benchmarks are defined as a map where the keys are a name for the given
+    function and the values are the functions to benchmark. Users can configure
+    the run by passing a keyword list as the second argument. For more
+    information on configuration see `Benchee.Configuration.init/1`.
 
     ## Examples
 
-        Benchee.run(%{"My Benchmark" => fn -> 1 + 1 end,
-                      "My other benchmrk" => fn -> "1" ++ "1" end}, time: 3)
-        # Prints a summary of the benchmark to the console
-
+        Benchee.run(
+          %{
+            "My Benchmark" => fn -> 1 + 1 end,
+            "My other benchmrk" => fn -> [1] ++ [1] end
+          },
+          warmup: 2,
+          time: 3
+        )
     """
-    def run(jobs, config \\ [])
-
-    def run(jobs, config) when is_list(config) do
-      do_run(jobs, config)
-    end
-
-    def run(config, jobs) when is_map(jobs) do
-      IO.puts("""
-      Passing configuration as the first argument to Benchee.run/2 is deprecated.
-      Please see the documentation for Benchee.run/2 for updated usage instructions.
-      """)
-
-      # pre 0.6.0 way of passing in the config first and as a map
-      do_run(jobs, config)
-    end
-
-    defp do_run(jobs, config) do
+    @spec run(map, keyword) :: any
+    def run(jobs, config \\ []) when is_list(config) do
       config
       |> Benchee.init()
       |> Benchee.system()
@@ -69,15 +56,6 @@ for {module, moduledoc} <- [{Benchee, elixir_doc}, {:benchee, erlang_doc}] do
       Enum.reduce(jobs, suite, fn {key, function}, suite_acc ->
         Benchee.benchmark(suite_acc, key, function)
       end)
-    end
-
-    @doc false
-    def measure(suite) do
-      IO.puts("""
-      Benchee.measure/1 is deprecated, please use Benchee.collect/1.
-      """)
-
-      Benchee.Benchmark.collect(suite)
     end
 
     @doc """

--- a/lib/benchee/benchmark.ex
+++ b/lib/benchee/benchmark.ex
@@ -48,19 +48,6 @@ defmodule Benchee.Benchmark do
     %Suite{suite | scenarios: List.flatten([scenarios | new_scenarios])}
   end
 
-  defp build_scenarios_for_job(job_name, function, config)
-
-  defp build_scenarios_for_job(job_name, function, nil) do
-    [
-      build_scenario(%{
-        job_name: job_name,
-        function: function,
-        input: @no_input,
-        input_name: @no_input
-      })
-    ]
-  end
-
   defp build_scenarios_for_job(job_name, function, %{inputs: nil}) do
     [
       build_scenario(%{

--- a/lib/benchee/configuration.ex
+++ b/lib/benchee/configuration.ex
@@ -291,7 +291,6 @@ defmodule Benchee.Configuration do
       |> standardized_user_configuration
       |> merge_with_defaults
       |> convert_time_to_nano_s
-      |> update_measure_memory
       |> save_option_conversion
 
     %Suite{configuration: config}
@@ -337,29 +336,6 @@ defmodule Benchee.Configuration do
 
       new_config
     end)
-  end
-
-  defp update_measure_memory(config = %{memory_time: memory_time}) do
-    otp_version = List.to_integer(:erlang.system_info(:otp_release))
-
-    if memory_time > 0 and otp_version <= 18 do
-      print_memory_measure_warning()
-      Map.put(config, :memory_time, 0)
-    else
-      config
-    end
-  end
-
-  defp print_memory_measure_warning do
-    IO.puts("""
-
-      Measuring memory consumption is only available on OTP 19 or greater.
-      If you would like to benchmark memory consumption, please upgrade to a
-      newer version of OTP.
-      Benchee now also only supports elixir ~> 1.6 which doesn't support OTP 18.
-      Please upgrade :)
-
-    """)
   end
 
   defp save_option_conversion(config = %{save: false}), do: config

--- a/lib/benchee/formatters/console.ex
+++ b/lib/benchee/formatters/console.ex
@@ -79,8 +79,6 @@ defmodule Benchee.Formatters.Console do
   @impl true
   @spec format(Suite.t(), map) :: [any]
   def format(%Suite{scenarios: scenarios, configuration: config}, options \\ %{}) do
-    if Map.has_key?(options, :unit_scaling), do: warn_unit_scaling()
-
     config =
       config
       |> Map.take([:unit_scaling, :title])
@@ -116,12 +114,6 @@ defmodule Benchee.Formatters.Console do
     IO.write(output)
   rescue
     _ -> {:error, "Unknown Error"}
-  end
-
-  defp warn_unit_scaling do
-    IO.puts(
-      "unit_scaling is now a top level configuration option, avoid passing it as a formatter option."
-    )
   end
 
   defp generate_output(scenarios, config, input) do

--- a/test/benchee/configuration_test.exs
+++ b/test/benchee/configuration_test.exs
@@ -6,86 +6,45 @@ defmodule Benchee.ConfigurationTest do
 
   import DeepMerge
   import Benchee.Configuration
-  import ExUnit.CaptureIO
 
   @default_config %Configuration{}
 
   describe "init/1" do
     test "crashes for values that are going to be ignored" do
-      assert_raise KeyError, fn ->
-        init(runntime: 2)
-      end
+      assert_raise KeyError, fn -> init(runntime: 2) end
     end
 
     test "converts inputs map to a list and input keys to strings" do
-      suite = init(inputs: %{"map" => %{}, list: []})
-
-      assert %Suite{configuration: %{inputs: [{"list", []}, {"map", %{}}]}} = suite
+      assert %Suite{configuration: %{inputs: [{"list", []}, {"map", %{}}]}} =
+               init(inputs: %{"map" => %{}, list: []})
     end
 
-    test "doesn't convert input lists to maps" do
-      suite = init(inputs: [{"map", %{}}, {:list, []}])
-      assert %Suite{configuration: %{inputs: [{"map", %{}}, {"list", []}]}} = suite
+    test "doesn't convert input lists to maps and retains the order of input lists" do
+      assert %Suite{configuration: %{inputs: [{"map", %{}}, {"list", []}]}} =
+               init(inputs: [{"map", %{}}, {:list, []}])
     end
 
     test "loses duplicated inputs keys after normalization" do
-      suite = init(inputs: %{"map" => %{}, map: %{}})
-
-      assert %Suite{configuration: %{inputs: inputs}} = suite
-      assert [{"map", %{}}] == inputs
+      assert %Suite{configuration: %{inputs: [{"map", %{}}]}} =
+               init(inputs: %{"map" => %{}, map: %{}})
     end
 
     test "uses information from :save to setup the external term formattter" do
-      suite = init(save: [path: "save_one.benchee", tag: "master"])
-
-      assert suite.configuration.formatters == [
-               Benchee.Formatters.Console,
-               {Benchee.Formatters.TaggedSave, %{path: "save_one.benchee", tag: "master"}}
-             ]
+      assert %Suite{
+               configuration: %{
+                 formatters: [
+                   Benchee.Formatters.Console,
+                   {Benchee.Formatters.TaggedSave, %{path: "save_one.benchee", tag: "master"}}
+                 ]
+               }
+             } = init(save: [path: "save_one.benchee", tag: "master"])
     end
 
     test ":save tag defaults to date" do
-      suite = init(save: [path: "save_one.benchee"])
+      assert %Suite{configuration: %{formatters: [_, {_, %{tag: tag, path: "save_one.benchee"}}]}} =
+               init(save: [path: "save_one.benchee"])
 
-      [_, {_, etf_options}] = suite.configuration.formatters
-
-      assert etf_options.tag =~ ~r/\d\d\d\d-\d\d?-\d\d?--\d\d?-\d\d?-\d\d?/
-      assert etf_options.path == "save_one.benchee"
-    end
-
-    test "takes formatter_options to build tuple list" do
-      suite =
-        init(
-          formatter_options: %{console: %{foo: :bar}},
-          formatters: [Benchee.Formatters.Console]
-        )
-
-      assert [{Benchee.Formatters.Console, %{foo: :bar}}] = suite.configuration.formatters
-    end
-
-    test "formatters already specified as a tuple are left alone" do
-      suite =
-        init(
-          formatter_options: %{console: %{foo: :bar}},
-          formatters: [{Benchee.Formatters.Console, %{a: :b}}]
-        )
-
-      assert [{Benchee.Formatters.Console, %{a: :b}}] == suite.configuration.formatters
-    end
-
-    test "legacy formatter options default to just the module if no options are given" do
-      suite = init(formatters: [Benchee.Formatter.CSV])
-
-      assert [Benchee.Formatter.CSV] == suite.configuration.formatters
-    end
-
-    test "it doesn't print anything in the default case" do
-      output =
-        capture_io(fn ->
-          init()
-        end)
-
-      assert output == ""
+      assert tag =~ ~r/\d\d\d\d-\d\d?-\d\d?--\d\d?-\d\d?-\d\d?/
     end
   end
 
@@ -114,9 +73,9 @@ defmodule Benchee.ConfigurationTest do
     end
 
     test "it just replaces when given another configuration" do
-      other_config = %Configuration{formatter_options: %{some: %{value: true}}}
+      other_config = %Configuration{print: %{some: %{value: true}}}
       result = deep_merge(@default_config, other_config)
-      expected = %Configuration{formatter_options: %{some: %{value: true}}}
+      expected = %Configuration{print: %{some: %{value: true}}}
 
       assert ^expected = result
     end

--- a/test/benchee_test.exs
+++ b/test/benchee_test.exs
@@ -79,23 +79,6 @@ defmodule BencheeTest do
     assert Regex.match?(body_regex("Magic"), output)
   end
 
-  test "integration high level README example old school map config" do
-    output =
-      capture_io(fn ->
-        list = Enum.to_list(1..10_000)
-        map_fun = fn i -> [i, i * i] end
-
-        map_config = Enum.into(@test_configuration, %{})
-
-        Benchee.run(map_config, %{
-          "flat_map" => fn -> Enum.flat_map(list, map_fun) end,
-          "map.flatten" => fn -> list |> Enum.map(map_fun) |> List.flatten() end
-        })
-      end)
-
-    readme_sample_asserts(output)
-  end
-
   test "integration high level README example but with formatter options" do
     output =
       capture_io(fn ->
@@ -234,7 +217,7 @@ defmodule BencheeTest do
             @test_configuration,
             time: 0.01,
             warmup: 0,
-            console: [comparison: false]
+            formatters: [{Console, %{comparison: false}}]
           )
         )
       end)
@@ -282,7 +265,7 @@ defmodule BencheeTest do
     readme_sample_asserts(output)
   end
 
-  test "formatters can be supplied with the Formatter.output/3 function" do
+  test "formatters can be supplied as a function with arity 1" do
     output =
       capture_io(fn ->
         list = Enum.to_list(1..10_000)


### PR DESCRIPTION
This builds off of #255, so that should be reviewed first.

This is still missing a comprehensive documentation overhaul, but this should be good enough for a 1.0 release candidate I think. Once that's out and we have an RC, we'll have some time to work on making documentation really good before 1.0 officially happens.

I'm going to open a separate PR that actually deprecates everything that is being removed in here, which we can merge first and release as 0.99.0 so folks have something to help them migrate to 1.0.