### PR TITLE
Relative statistics

### DIFF
--- a/.exguard.exs
+++ b/.exguard.exs
@@ -3,6 +3,12 @@ use ExGuard.Config
 project_files = ~r{\.(erl|ex|exs|eex|xrl|yrl)\z}i
 deps = ~r{deps}
 
+guard("compile and warn", run_on_start: true)
+|> command("MIX_ENV=test mix compile --warnings-as-errors")
+|> watch(project_files)
+|> ignore(deps)
+|> notification(:auto)
+
 guard("credo", run_on_start: true)
 |> command("mix credo --strict")
 |> watch(project_files)

--- a/lib/benchee/benchmark/repeated_measurement.ex
+++ b/lib/benchee/benchmark/repeated_measurement.ex
@@ -39,7 +39,7 @@ defmodule Benchee.Benchmark.RepeatedMeasurement do
     run_time = measure_iteration(scenario, scenario_context, collector)
 
     if run_time >= @minimum_execution_time do
-      {num_iterations, adjust_for_iterations(run_time, num_iterations)}
+      {num_iterations, report_time(run_time, num_iterations)}
     else
       if fast_warning, do: printer.fast_warning()
 
@@ -50,6 +50,14 @@ defmodule Benchee.Benchmark.RepeatedMeasurement do
 
       determine_n_times(scenario, new_context, false, collector)
     end
+  end
+
+  # we need to convert the time here since we measure native time to see when we have enough
+  # repetitions but the first time is used in the actual samples
+  defp report_time(measurement, num_iterations) do
+    measurement
+    |> :erlang.convert_time_unit(:native, :nanosecond)
+    |> adjust_for_iterations(num_iterations)
   end
 
   defp adjust_for_iterations(measurement, 1), do: measurement

--- a/lib/benchee/formatters/console/helpers.ex
+++ b/lib/benchee/formatters/console/helpers.ex
@@ -55,32 +55,43 @@ defmodule Benchee.Formatters.Console.Helpers do
         statistics,
         display_value,
         comparison_name,
+        display_unit,
         label_width,
         column_width
       ) do
-    "~*s~*s ~s"
+    "~*s~*s ~ts"
     |> :io_lib.format([
       -label_width,
       name,
       column_width,
       display_value,
-      comparison_display(statistics, comparison_name)
+      comparison_display(statistics, comparison_name, display_unit)
     ])
     |> to_string
   end
 
-  defp comparison_display(%Statistics{relative_more: nil, absolute_difference: nil}, _), do: ""
+  defp comparison_display(%Statistics{relative_more: nil, absolute_difference: nil}, _, _), do: ""
 
-  defp comparison_display(statistics, comparison_name) do
-    "- #{comparison_text(statistics, comparison_name)}\n"
+  defp comparison_display(statistics, comparison_name, unit) do
+    "- #{comparison_text(statistics, comparison_name)} - #{
+      absolute_difference_text(statistics, unit)
+    }\n"
   end
 
-  defp comparison_text(%Statistics{relative_more: :infinity}, name), do: "infinity x #{name}"
+  defp comparison_text(%Statistics{relative_more: :infinity}, name), do: " 	∞ x #{name}"
   defp comparison_text(%Statistics{relative_more: nil}, _), do: "N/A"
 
   defp comparison_text(statistics, comparison_name) do
     "~.2fx ~s"
     |> :io_lib.format([statistics.relative_more, comparison_name])
     |> to_string
+  end
+
+  defp absolute_difference_text(statistics, unit) do
+    formatted_value = Format.format({Scale.scale(statistics.absolute_difference, unit), unit})
+
+    # currently the fastest/least consuming is always first so everything else eats more
+    # resources hence this is always +
+    "+#{formatted_value}"
   end
 end

--- a/lib/benchee/formatters/console/helpers.ex
+++ b/lib/benchee/formatters/console/helpers.ex
@@ -49,4 +49,38 @@ defmodule Benchee.Formatters.Console.Helpers do
 
   @spec descriptor(String.t()) :: String.t()
   def descriptor(header_str), do: "\n#{header_str}: \n"
+
+  def format_comparison(
+        name,
+        statistics,
+        display_value,
+        comparison_name,
+        label_width,
+        column_width
+      ) do
+    "~*s~*s ~s"
+    |> :io_lib.format([
+      -label_width,
+      name,
+      column_width,
+      display_value,
+      comparison_display(statistics, comparison_name)
+    ])
+    |> to_string
+  end
+
+  defp comparison_display(%Statistics{relative_more: nil, absolute_difference: nil}, _), do: ""
+
+  defp comparison_display(statistics, comparison_name) do
+    "- #{comparison_text(statistics, comparison_name)}\n"
+  end
+
+  defp comparison_text(%Statistics{relative_more: :infinity}, name), do: "infinity x #{name}"
+  defp comparison_text(%Statistics{relative_more: nil}, _), do: "N/A"
+
+  defp comparison_text(statistics, comparison_name) do
+    "~.2fx ~s"
+    |> :io_lib.format([statistics.relative_more, comparison_name])
+    |> to_string
+  end
 end

--- a/lib/benchee/formatters/console/helpers.ex
+++ b/lib/benchee/formatters/console/helpers.ex
@@ -78,7 +78,7 @@ defmodule Benchee.Formatters.Console.Helpers do
     }\n"
   end
 
-  defp comparison_text(%Statistics{relative_more: :infinity}, name), do: " 	∞ x #{name}"
+  defp comparison_text(%Statistics{relative_more: :infinity}, name), do: "∞ x #{name}"
   defp comparison_text(%Statistics{relative_more: nil}, _), do: "N/A"
 
   defp comparison_text(statistics, comparison_name) do
@@ -90,8 +90,10 @@ defmodule Benchee.Formatters.Console.Helpers do
   defp absolute_difference_text(statistics, unit) do
     formatted_value = Format.format({Scale.scale(statistics.absolute_difference, unit), unit})
 
-    # currently the fastest/least consuming is always first so everything else eats more
-    # resources hence this is always +
-    "+#{formatted_value}"
+    if statistics.absolute_difference >= 0 do
+      "+#{formatted_value}"
+    else
+      formatted_value
+    end
   end
 end

--- a/lib/benchee/formatters/console/helpers.ex
+++ b/lib/benchee/formatters/console/helpers.ex
@@ -73,7 +73,7 @@ defmodule Benchee.Formatters.Console.Helpers do
   defp comparison_display(%Statistics{relative_more: nil, absolute_difference: nil}, _, _), do: ""
 
   defp comparison_display(statistics, comparison_name, unit) do
-    "- #{comparison_text(statistics, comparison_name)} - #{
+    "- #{comparison_text(statistics, comparison_name)} #{
       absolute_difference_text(statistics, unit)
     }\n"
   end

--- a/lib/benchee/formatters/console/memory.ex
+++ b/lib/benchee/formatters/console/memory.ex
@@ -233,44 +233,20 @@ defmodule Benchee.Formatters.Console.Memory do
 
     Enum.map(
       scenarios_to_compare,
-      fn scenario = %Scenario{memory_usage_data: %{statistics: job_stats}} ->
-        slower = calculate_slower_value(job_stats.median, reference_stats.median)
+      fn scenario ->
+        statistics = scenario.memory_usage_data.statistics
+        memory_format = memory_output(statistics.average, units.memory)
 
-        format_comparison(scenario, units, label_width, slower)
+        Helpers.format_comparison(
+          scenario.name,
+          statistics,
+          memory_format,
+          "memory usage",
+          label_width,
+          @median_width
+        )
       end
     )
-  end
-
-  defp calculate_slower_value(job_median, reference_median)
-       when job_median == 0 or is_nil(job_median) or reference_median == 0 or
-              is_nil(reference_median) do
-    @na
-  end
-
-  defp calculate_slower_value(job_median, reference_median) do
-    job_median / reference_median
-  end
-
-  defp format_comparison(scenario, %{memory: memory_unit}, label_width, @na) do
-    %Scenario{name: name, memory_usage_data: %{statistics: %Statistics{median: median}}} =
-      scenario
-
-    median_format = memory_output(median, memory_unit)
-
-    "~*s~*s\n"
-    |> :io_lib.format([-label_width, name, @median_width, median_format])
-    |> to_string
-  end
-
-  defp format_comparison(scenario, %{memory: memory_unit}, label_width, slower) do
-    %Scenario{name: name, memory_usage_data: %{statistics: %Statistics{median: median}}} =
-      scenario
-
-    median_format = memory_output(median, memory_unit)
-
-    "~*s~*s - ~.2fx memory usage\n"
-    |> :io_lib.format([-label_width, name, @median_width, median_format, slower])
-    |> to_string
   end
 
   defp memory_output(nil, _unit), do: "N/A"

--- a/lib/benchee/formatters/console/memory.ex
+++ b/lib/benchee/formatters/console/memory.ex
@@ -106,7 +106,7 @@ defmodule Benchee.Formatters.Console.Memory do
   defp scenario_reports([scenario | other_scenarios], units, label_width, true) do
     [
       reference_report(scenario, units, label_width),
-      comparisons(scenario, units, label_width, other_scenarios),
+      comparisons(other_scenarios, units, label_width),
       "\n**All measurements for memory usage were the same**\n"
     ]
   end
@@ -209,7 +209,7 @@ defmodule Benchee.Formatters.Console.Memory do
     [
       Helpers.descriptor("Comparison"),
       reference_report(scenario, units, label_width)
-      | comparisons(scenario, units, label_width, other_scenarios)
+      | comparisons(other_scenarios, units, label_width)
     ]
   end
 
@@ -227,10 +227,8 @@ defmodule Benchee.Formatters.Console.Memory do
     |> to_string
   end
 
-  @spec comparisons(Scenario.t(), unit_per_statistic, integer, [Scenario.t()]) :: [String.t()]
-  defp comparisons(scenario, units, label_width, scenarios_to_compare) do
-    %Scenario{memory_usage_data: %{statistics: reference_stats}} = scenario
-
+  @spec comparisons([Scenario.t()], unit_per_statistic, integer) :: [String.t()]
+  defp comparisons(scenarios_to_compare, units, label_width) do
     Enum.map(
       scenarios_to_compare,
       fn scenario ->
@@ -242,6 +240,7 @@ defmodule Benchee.Formatters.Console.Memory do
           statistics,
           memory_format,
           "memory usage",
+          units.memory,
           label_width,
           @median_width
         )

--- a/lib/benchee/formatters/console/run_time.ex
+++ b/lib/benchee/formatters/console/run_time.ex
@@ -239,7 +239,7 @@ defmodule Benchee.Formatters.Console.RunTime do
     [
       Helpers.descriptor("Comparison"),
       reference_report(scenario, units, label_width)
-      | comparisons(scenario, units, label_width, other_scenarios)
+      | comparisons(other_scenarios, units, label_width)
     ]
   end
 
@@ -251,26 +251,24 @@ defmodule Benchee.Formatters.Console.RunTime do
     |> to_string
   end
 
-  @spec comparisons(Scenario.t(), unit_per_statistic, integer, [Scenario.t()]) :: [String.t()]
-  defp comparisons(scenario, units, label_width, scenarios_to_compare) do
-    %Scenario{run_time_data: %{statistics: reference_stats}} = scenario
-
+  @spec comparisons([Scenario.t()], unit_per_statistic, integer) :: [String.t()]
+  defp comparisons(scenarios_to_compare, units, label_width) do
     Enum.map(
       scenarios_to_compare,
-      fn scenario = %Scenario{run_time_data: %{statistics: job_stats}} ->
-        slower = reference_stats.ips / job_stats.ips
-        format_comparison(scenario, units, label_width, slower)
+      fn scenario ->
+        statistics = scenario.run_time_data.statistics
+        ips_format = Helpers.count_output(statistics.ips, units.ips)
+
+        Helpers.format_comparison(
+          scenario.name,
+          statistics,
+          ips_format,
+          "slower",
+          label_width,
+          @ips_width
+        )
       end
     )
-  end
-
-  defp format_comparison(scenario, %{ips: ips_unit}, label_width, slower) do
-    %Scenario{name: name, run_time_data: %{statistics: %Statistics{ips: ips}}} = scenario
-    ips_format = Helpers.count_output(ips, ips_unit)
-
-    "~*s~*s - ~.2fx slower\n"
-    |> :io_lib.format([-label_width, name, @ips_width, ips_format, slower])
-    |> to_string
   end
 
   defp duration_output(duration, unit) do

--- a/lib/benchee/formatters/console/run_time.ex
+++ b/lib/benchee/formatters/console/run_time.ex
@@ -264,6 +264,7 @@ defmodule Benchee.Formatters.Console.RunTime do
           statistics,
           ips_format,
           "slower",
+          units.run_time,
           label_width,
           @ips_width
         )

--- a/lib/benchee/statistics.ex
+++ b/lib/benchee/statistics.ex
@@ -23,6 +23,9 @@ defmodule Benchee.Statistics do
     :mode,
     :minimum,
     :maximum,
+    :relative_more,
+    :relative_less,
+    :absolute_difference,
     sample_size: 0
   ]
 
@@ -71,6 +74,9 @@ defmodule Benchee.Statistics do
           mode: mode,
           minimum: number,
           maximum: number,
+          relative_more: float | nil | :infinity,
+          relative_less: float | nil | :infinity,
+          absolute_difference: float | nil,
           sample_size: integer
         }
 
@@ -151,21 +157,28 @@ defmodule Benchee.Statistics do
   def statistics(suite = %Suite{scenarios: scenarios}) do
     config = suite.configuration
 
+    scenarios_with_statistics =
+      scenarios
+      |> calculate_per_scenario_statistics(config)
+      |> sort()
+      |> calculate_relative_statistics(config.inputs)
+
+    %Suite{suite | scenarios: scenarios_with_statistics}
+  end
+
+  defp calculate_per_scenario_statistics(scenarios, config) do
     percentiles = Enum.uniq([50 | config.percentiles])
 
-    scenarios_with_statistics =
-      Parallel.map(scenarios, fn scenario ->
-        run_time_stats = scenario.run_time_data.samples |> job_statistics(percentiles) |> add_ips
-        memory_stats = job_statistics(scenario.memory_usage_data.samples, percentiles)
+    Parallel.map(scenarios, fn scenario ->
+      run_time_stats = scenario.run_time_data.samples |> job_statistics(percentiles) |> add_ips
+      memory_stats = job_statistics(scenario.memory_usage_data.samples, percentiles)
 
-        %{
-          scenario
-          | run_time_data: %{scenario.run_time_data | statistics: run_time_stats},
-            memory_usage_data: %{scenario.memory_usage_data | statistics: memory_stats}
-        }
-      end)
-
-    %Suite{suite | scenarios: sort(scenarios_with_statistics)}
+      %{
+        scenario
+        | run_time_data: %{scenario.run_time_data | statistics: run_time_stats},
+          memory_usage_data: %{scenario.memory_usage_data | statistics: memory_stats}
+      }
+    end)
   end
 
   @spec job_statistics(samples, list) :: __MODULE__.t()
@@ -222,6 +235,141 @@ defmodule Benchee.Statistics do
       | ips: ips,
         std_dev_ips: standard_dev_ips
     }
+  end
+
+  defp calculate_relative_statistics([], _inputs), do: []
+
+  defp calculate_relative_statistics(scenarios, inputs) do
+    scenarios
+    |> scenarios_by_input(inputs)
+    |> Enum.flat_map(fn scenarios_with_same_input ->
+      {reference, others} = split_reference_scenario(scenarios_with_same_input)
+      others_with_relative = statistics_relative_to(others, reference)
+      [reference | others_with_relative]
+    end)
+  end
+
+  defp scenarios_by_input(scenarios, nil), do: [scenarios]
+
+  # we can't just group_by `input_name` because that'd lose the order of inputs which might
+  # be important
+  defp scenarios_by_input(scenarios, inputs) do
+    Enum.map(inputs, fn {input_name, _} ->
+      Enum.filter(scenarios, fn scenario -> scenario.input_name == input_name end)
+    end)
+  end
+
+  # right now we take the first scenario as we sorted them and it is the fastest,
+  # whenever we implement #179 though this becomesd more involved
+  defp split_reference_scenario(scenarios) do
+    [reference | others] = scenarios
+    {reference, others}
+  end
+
+  defp statistics_relative_to(scenarios, reference) do
+    Enum.map(scenarios, fn scenario ->
+      scenario
+      |> update_in([Access.key!(:run_time_data), Access.key!(:statistics)], fn statistics ->
+        add_relative_statistics(statistics, reference.run_time_data.statistics)
+      end)
+      |> update_in([Access.key!(:memory_usage_data), Access.key!(:statistics)], fn statistics ->
+        add_relative_statistics(statistics, reference.memory_usage_data.statistics)
+      end)
+    end)
+  end
+
+  # we might not run time/memory --> we shouldn't crash then ;)
+  defp add_relative_statistics(statistics = %{average: nil}, _reference), do: statistics
+  defp add_relative_statistics(statistics, %{average: nil}), do: statistics
+
+  defp add_relative_statistics(statistics, reference_statistics) do
+    %__MODULE__{
+      statistics
+      | relative_more: zero_safe_division(statistics.average, reference_statistics.average),
+        relative_less: zero_safe_division(reference_statistics.average, statistics.average),
+        absolute_difference: statistics.average - reference_statistics.average
+    }
+  end
+
+  defp zero_safe_division(_, 0), do: :infinity
+  defp zero_safe_division(_, 0.0), do: :infinity
+  defp zero_safe_division(a, b), do: a / b
+
+  @doc """
+  Calculate additional percentiles and add them to the
+  `run_time_data.statistics`. Should only be used after `statistics/1`, to
+  calculate extra values that may be needed for reporting.
+
+  ## Examples
+
+      iex> scenarios = [
+      ...>   %Benchee.Scenario{
+      ...>     job_name: "My Job",
+      ...>     run_time_data: %Benchee.CollectionData{
+      ...>       samples: [200, 400, 400, 400, 500, 500, 500, 700, 900]
+      ...>     },
+      ...>     memory_usage_data: %Benchee.CollectionData{
+      ...>       samples: [200, 400, 400, 400, 500, 500, 500, 700, 900]
+      ...>     },
+      ...>     input_name: "Input",
+      ...>     input: "Input"
+      ...>   }
+      ...> ]
+      iex> %Benchee.Suite{scenarios: scenarios}
+      ...> |> Benchee.Statistics.statistics
+      ...> |> Benchee.Statistics.add_percentiles([25, 75])
+      %Benchee.Suite{
+        scenarios: [
+          %Benchee.Scenario{
+            job_name: "My Job",
+            input_name: "Input",
+            input: "Input",
+            run_time_data: %Benchee.CollectionData{
+              samples: [200, 400, 400, 400, 500, 500, 500, 700, 900],
+              statistics: %Benchee.Statistics{
+                average:       500.0,
+                ips:           2_000_000.0,
+                std_dev:       200.0,
+                std_dev_ratio: 0.4,
+                std_dev_ips:   800_000.0,
+                median:        500.0,
+                percentiles:   %{25 => 400.0, 50 => 500.0, 75 => 600.0, 99 => 900.0},
+                mode:          [500, 400],
+                minimum:       200,
+                maximum:       900,
+                sample_size:   9
+              }
+            },
+            memory_usage_data: %Benchee.CollectionData{
+              samples: [200, 400, 400, 400, 500, 500, 500, 700, 900],
+              statistics: %Benchee.Statistics{
+                average:       500.0,
+                ips:           nil,
+                std_dev:       200.0,
+                std_dev_ratio: 0.4,
+                std_dev_ips:   nil,
+                median:        500.0,
+                percentiles:   %{50 => 500.0, 99 => 900.0},
+                mode:          [500, 400],
+                minimum:       200,
+                maximum:       900,
+                sample_size:   9
+              }
+            }
+          }
+        ]
+      }
+  """
+  def add_percentiles(suite = %Suite{scenarios: scenarios}, percentile_ranks) do
+    new_scenarios =
+      Parallel.map(scenarios, fn scenario ->
+        update_in(scenario.run_time_data.statistics.percentiles, fn existing ->
+          new = Percentile.percentiles(scenario.run_time_data.samples, percentile_ranks)
+          Map.merge(existing, new)
+        end)
+      end)
+
+    %Suite{suite | scenarios: new_scenarios}
   end
 
   @spec sort([Scenario.t()]) :: [Scenario.t()]

--- a/lib/benchee/statistics.ex
+++ b/lib/benchee/statistics.ex
@@ -59,8 +59,17 @@ defmodule Benchee.Statistics do
     * mode          - the run time(s) that occur the most. Often one value, but
       can be multiple values if they occur the same amount of times. If no value
       occurs at least twice, this value will be nil.
-    * minimum       - the smallest (fastest) run time measured for the job
-    * maximum       - the biggest (slowest) run time measured for the job
+    * minimum       - the smallest sample measured for the scenario
+    * maximum       - the biggest sample measured for the scenario
+    * relative_more - relative to the reference (usually the fastest scenario) how much more
+      was the average of this scenario. E.g. for reference at 100, this scenario 200 then it
+      is 2.0.
+    * relative_less - relative to the reference (usually the fastest scenario) how much less
+      was the average of this scenario. E.g. for reference at 100, this scenario 200 then it
+      is 0.5.
+    * absolute_difference - relative to the reference (usually the fastest scenario) what is
+      the difference of the averages of the scenarios. e.g. for reference at 100, this
+      scenario 200 then it is 100.
     * sample_size   - the number of run time measurements taken
   """
   @type t :: %__MODULE__{

--- a/lib/benchee/statistics.ex
+++ b/lib/benchee/statistics.ex
@@ -186,17 +186,17 @@ defmodule Benchee.Statistics do
     %__MODULE__{sample_size: 0}
   end
 
-  defp job_statistics(measurements, percentiles) do
-    total = Enum.sum(measurements)
-    num_iterations = length(measurements)
+  defp job_statistics(samples, percentiles) do
+    total = Enum.sum(samples)
+    num_iterations = length(samples)
     average = total / num_iterations
-    deviation = standard_deviation(measurements, average, num_iterations)
+    deviation = standard_deviation(samples, average, num_iterations)
     standard_dev_ratio = if average == 0, do: 0, else: deviation / average
-    percentiles = Percentile.percentiles(measurements, percentiles)
+    percentiles = Percentile.percentiles(samples, percentiles)
     median = Map.fetch!(percentiles, 50)
-    mode = Mode.mode(measurements)
-    minimum = Enum.min(measurements)
-    maximum = Enum.max(measurements)
+    mode = Mode.mode(samples)
+    minimum = Enum.min(samples)
+    maximum = Enum.max(samples)
 
     %__MODULE__{
       average: average,
@@ -291,6 +291,7 @@ defmodule Benchee.Statistics do
     }
   end
 
+  defp zero_safe_division(0.0, 0.0), do: 1.0
   defp zero_safe_division(_, 0), do: :infinity
   defp zero_safe_division(_, 0.0), do: :infinity
   defp zero_safe_division(a, b), do: a / b

--- a/samples/fast.exs
+++ b/samples/fast.exs
@@ -1,0 +1,12 @@
+list = Enum.to_list(1..10_000)
+map_fun = fn i -> [i, i * i] end
+
+Benchee.run(
+  %{
+    "flat_map" => fn -> Enum.flat_map(list, map_fun) end,
+    "map.flatten" => fn -> list |> Enum.map(map_fun) |> List.flatten() end
+  },
+  warmup: 0.1,
+  time: 0.3,
+  memory_time: 0.3
+)

--- a/samples/run.exs
+++ b/samples/run.exs
@@ -11,13 +11,13 @@ Benchee.run(
 )
 
 # tobi@speedy:~/github/benchee(master)$ mix run samples/run.exs
-# Operating System: Linux"
+# Operating System: Linux
 # CPU Information: Intel(R) Core(TM) i7-4790 CPU @ 3.60GHz
 # Number of Available Cores: 8
 # Available memory: 15.61 GB
-# Elixir 1.6.4
-# Erlang 20.3
-#
+# Elixir 1.8.1
+# Erlang 21.2.7
+
 # Benchmark suite executing with the following configuration:
 # warmup: 2 s
 # time: 10 s
@@ -25,23 +25,23 @@ Benchee.run(
 # parallel: 1
 # inputs: none specified
 # Estimated total run time: 28 s
-#
-#
+
+
 # Benchmarking flat_map...
 # Benchmarking map.flatten...
-#
+
 # Name                  ips        average  deviation         median         99th %
-# flat_map           2.31 K      433.25 μs     ±8.64%         428 μs         729 μs
-# map.flatten        1.22 K      822.22 μs    ±16.43%         787 μs        1203 μs
-#
+# flat_map           2.36 K      424.38 μs    ±13.24%      411.19 μs      761.59 μs
+# map.flatten        1.24 K      806.83 μs    ±16.60%      767.85 μs     1189.10 μs
+
 # Comparison:
-# flat_map           2.31 K
-# map.flatten        1.22 K - 1.90x slower
-#
+# flat_map           2.36 K
+# map.flatten        1.24 K - 1.90x slower - +382.45 μs
+
 # Memory usage statistics:
-#
+
 # Name           Memory usage
-# flat_map          625.54 KB
-# map.flatten       781.85 KB - 1.25x memory usage
-#
+# flat_map          624.97 KB
+# map.flatten       781.25 KB - 1.25x memory usage - +156.28 KB
+
 # **All measurements for memory usage were the same**

--- a/samples/run.exs
+++ b/samples/run.exs
@@ -26,7 +26,6 @@ Benchee.run(
 # inputs: none specified
 # Estimated total run time: 28 s
 
-
 # Benchmarking flat_map...
 # Benchmarking map.flatten...
 

--- a/test/benchee/benchmark/repeated_measurement_test.exs
+++ b/test/benchee/benchmark/repeated_measurement_test.exs
@@ -38,8 +38,12 @@ defmodule Bencheee.Benchmark.RepeatedMeasurementTest do
         determine_n_times(scenario, @scenario_context, false, FakeCollector)
 
       assert num_iterations == 10
+
       # 50 adjusted by the 10 iteration factor
-      assert time == 5
+      # we need to use convert_time_unit cos windows is funny, see:
+      # https://twitter.com/PragTob/status/1108024728734838784
+      expected_time = :erlang.convert_time_unit(5, :native, :nanosecond)
+      assert_in_delta time, expected_time, 1
 
       # 1 initial + 10 more after repeat
       assert_received_exactly_n_times(:called, 11)
@@ -54,7 +58,10 @@ defmodule Bencheee.Benchmark.RepeatedMeasurementTest do
         determine_n_times(scenario, @scenario_context, false, FakeCollector)
 
       assert num_iterations == 1
-      assert time == 10
+
+      # Why erlang time conversion? See test above.
+      expected_time = :erlang.convert_time_unit(10, :native, :nanosecond)
+      assert_in_delta time, expected_time, 1
 
       # 1 initial + 10 more after repeat
       assert_received_exactly_n_times(:called, 1)

--- a/test/benchee/formatters/console/memory_test.exs
+++ b/test/benchee/formatters/console/memory_test.exs
@@ -123,9 +123,9 @@ defmodule Benchee.Formatters.Console.MemoryTest do
       output = Memory.format_scenarios(scenarios, @console_config)
       [_, _, _, _, comp_header, reference, slower] = output
 
-      assert Regex.match?(~r/Comparison/, comp_header)
-      assert Regex.match?(~r/^First\s+90 B$/m, reference)
-      assert Regex.match?(~r/^Second\s+195.50 B\s+- 2.17x memory usage/, slower)
+      assert comp_header =~ ~r/Comparison/
+      assert reference =~ ~r/^First\s+90 B$/m
+      assert slower =~ ~r/^Second\s+195.50 B\s+- 2.17x memory usage - \+105\.50 B$/m
     end
 
     test "can omit the comparisons" do
@@ -169,9 +169,9 @@ defmodule Benchee.Formatters.Console.MemoryTest do
           })
         )
 
-      refute Regex.match?(~r/Comparison/i, output)
-      refute Regex.match?(~r/^First\s+90 B$/m, output)
-      refute Regex.match?(~r/^Second\s+195.50 B\s+- 2.17x memory usage/, output)
+      refute output =~ ~r/Comparison/i
+      refute output =~ ~r/^First\s+90 B$/m
+      refute output =~ ~r/^Second\s+195.50 B\s+- 2.17x memory usage/
     end
 
     test "adjusts the label width to longest name for comparisons" do
@@ -318,16 +318,16 @@ defmodule Benchee.Formatters.Console.MemoryTest do
       output = Memory.format_scenarios(scenarios, params)
       [_memory_title, _header1, _result1, title, header2, result2] = output
 
-      assert title =~ ~r/Extended statistics: /
-      assert header2 =~ ~r/minimum/
-      assert header2 =~ ~r/maximum/
-      assert header2 =~ ~r/sample size/
-      assert header2 =~ ~r/mode/
-      assert result2 =~ ~r/First job/
-      assert result2 =~ ~r/111.10/
-      assert result2 =~ ~r/333.30/
-      assert result2 =~ ~r/50 K/
-      assert result2 =~ ~r/201.20/
+      assert title =~ "Extended statistics: "
+      assert header2 =~ "minimum"
+      assert header2 =~ "maximum"
+      assert header2 =~ "sample size"
+      assert header2 =~ "mode"
+      assert result2 =~ "First job"
+      assert result2 =~ "111.10"
+      assert result2 =~ "333.30"
+      assert result2 =~ "50 K"
+      assert result2 =~ "201.20"
     end
 
     test "does nothing when there's no statistics to format" do
@@ -422,7 +422,7 @@ defmodule Benchee.Formatters.Console.MemoryTest do
 
       assert output =~ "First"
       assert output =~ "Second"
-      assert output =~ "infinity x memory usage"
+      assert output =~ "∞ x memory usage"
     end
 
     test "it doesn't blow up if some come back with a median et. al. of nil" do

--- a/test/benchee/formatters/console/memory_test.exs
+++ b/test/benchee/formatters/console/memory_test.exs
@@ -125,7 +125,7 @@ defmodule Benchee.Formatters.Console.MemoryTest do
 
       assert comp_header =~ ~r/Comparison/
       assert reference =~ ~r/^First\s+90 B$/m
-      assert slower =~ ~r/^Second\s+195.50 B\s+- 2.17x memory usage - \+105\.50 B$/m
+      assert slower =~ ~r/^Second\s+195.50 B\s+- 2.17x memory usage \+105\.50 B$/m
     end
 
     test "can omit the comparisons" do

--- a/test/benchee/formatters/console/memory_test.exs
+++ b/test/benchee/formatters/console/memory_test.exs
@@ -36,7 +36,9 @@ defmodule Benchee.Formatters.Console.MemoryTest do
               std_dev_ratio: 0.1,
               median: 375.0,
               percentiles: %{99 => 400.1},
-              sample_size: 10
+              sample_size: 10,
+              relative_more: 2.0,
+              absolute_difference: 200.0
             }
           },
           run_time_data: %CollectionData{statistics: %Statistics{average: 100.0, ips: 1_000.0}}
@@ -64,7 +66,9 @@ defmodule Benchee.Formatters.Console.MemoryTest do
             std_dev_ratio: 0.1,
             median: 375.0,
             percentiles: %{99 => 500.1},
-            sample_size: 10
+            sample_size: 10,
+            relative_more: 2.005,
+            absolute_difference: 200.1
           }
         },
         run_time_data: %CollectionData{statistics: %Statistics{average: 100.0, ips: 1_000.0}}
@@ -88,7 +92,7 @@ defmodule Benchee.Formatters.Console.MemoryTest do
           name: "First",
           memory_usage_data: %CollectionData{
             statistics: %Statistics{
-              average: 100.0,
+              average: 90.0,
               ips: 10_000.0,
               std_dev_ratio: 0.1,
               median: 90.0,
@@ -102,12 +106,14 @@ defmodule Benchee.Formatters.Console.MemoryTest do
           name: "Second",
           memory_usage_data: %CollectionData{
             statistics: %Statistics{
-              average: 200.0,
+              average: 195.5,
               ips: 5_000.0,
               std_dev_ratio: 0.1,
               median: 195.5,
               percentiles: %{99 => 500.1},
-              sample_size: 10
+              sample_size: 10,
+              relative_more: 2.17,
+              absolute_difference: 105.5
             }
           },
           run_time_data: %CollectionData{statistics: %Statistics{average: 100.0, ips: 1_000.0}}
@@ -195,7 +201,9 @@ defmodule Benchee.Formatters.Console.MemoryTest do
               std_dev_ratio: 0.1,
               median: 195.5,
               percentiles: %{99 => 300.1},
-              sample_size: 10
+              sample_size: 10,
+              relative_more: 2.0,
+              absolute_difference: 100.0
             }
           },
           run_time_data: %CollectionData{statistics: %Statistics{average: 100.0, ips: 1_000.0}}
@@ -258,7 +266,9 @@ defmodule Benchee.Formatters.Console.MemoryTest do
               std_dev_ratio: 0.0,
               median: 200.0,
               percentiles: %{99 => 200.0},
-              sample_size: 10
+              sample_size: 10,
+              relative_more: 2.0,
+              absolute_difference: 100.0
             }
           },
           run_time_data: %CollectionData{statistics: %Statistics{average: 100.0, ips: 1_000.0}}
@@ -392,7 +402,9 @@ defmodule Benchee.Formatters.Console.MemoryTest do
               sample_size: 5,
               percentiles: %{99 => 100.0},
               std_dev: 5.0,
-              std_dev_ratio: 0.10
+              std_dev_ratio: 0.10,
+              relative_more: :infinity,
+              absolute_difference: 100.0
             }
           },
           run_time_data: %CollectionData{statistics: %Statistics{}}
@@ -410,7 +422,7 @@ defmodule Benchee.Formatters.Console.MemoryTest do
 
       assert output =~ "First"
       assert output =~ "Second"
-      refute output =~ "x memory usage"
+      assert output =~ "infinity x memory usage"
     end
 
     test "it doesn't blow up if some come back with a median et. al. of nil" do

--- a/test/benchee/formatters/console/run_time_test.exs
+++ b/test/benchee/formatters/console/run_time_test.exs
@@ -218,9 +218,9 @@ defmodule Benchee.Formatters.Console.RunTimeTest do
       [_, _, _, comp_header, reference, slower] =
         RunTime.format_scenarios(scenarios, @console_config)
 
-      assert Regex.match?(~r/Comparison/, comp_header)
-      assert Regex.match?(~r/^First\s+10 K$/m, reference)
-      assert Regex.match?(~r/^Second\s+5 K\s+- 2.00x slower/, slower)
+      assert comp_header =~ ~r/Comparison/
+      assert reference =~ ~r/^First\s+10 K$/m
+      assert slower =~ ~r/^Second\s+5 K\s+- 2.00x slower - \+100 ns$/m
     end
 
     test "can omit the comparisons" do
@@ -263,9 +263,9 @@ defmodule Benchee.Formatters.Console.RunTimeTest do
           })
         )
 
-      refute Regex.match?(~r/Comparison/i, output)
-      refute Regex.match?(~r/^First\s+10 K$/m, output)
-      refute Regex.match?(~r/^Second\s+5 K\s+- 2.00x slower/, output)
+      refute output =~ ~r/Comparison/i
+      refute output =~ ~r/^First\s+10 K$/m
+      refute output =~ ~r/^Second\s+5 K\s+- 2.00x slower/
     end
 
     test "adjusts the label width to longest name for comparisons" do

--- a/test/benchee/formatters/console/run_time_test.exs
+++ b/test/benchee/formatters/console/run_time_test.exs
@@ -131,7 +131,9 @@ defmodule Benchee.Formatters.Console.RunTimeTest do
               std_dev_ratio: 0.1,
               median: 375.0,
               percentiles: %{99 => 400.1},
-              sample_size: 300
+              sample_size: 300,
+              relative_more: 2.0,
+              absolute_difference: 200.0
             }
           },
           memory_usage_data: %CollectionData{statistics: %Statistics{}}
@@ -159,7 +161,9 @@ defmodule Benchee.Formatters.Console.RunTimeTest do
             std_dev_ratio: 0.1,
             median: 375.0,
             percentiles: %{99 => 500.1},
-            sample_size: 200
+            sample_size: 200,
+            relative_more: 2.005,
+            absolute_difference: 200.1
           }
         },
         memory_usage_data: %CollectionData{statistics: %Statistics{}}
@@ -202,7 +206,9 @@ defmodule Benchee.Formatters.Console.RunTimeTest do
               std_dev_ratio: 0.1,
               median: 195.5,
               percentiles: %{99 => 500.1},
-              sample_size: 200
+              sample_size: 200,
+              relative_more: 2.0,
+              absolute_difference: 100.0
             }
           },
           memory_usage_data: %CollectionData{statistics: %Statistics{}}
@@ -289,7 +295,9 @@ defmodule Benchee.Formatters.Console.RunTimeTest do
               std_dev_ratio: 0.1,
               median: 195.5,
               percentiles: %{99 => 300.1},
-              sample_size: 200
+              sample_size: 200,
+              relative_more: 2.0,
+              absolute_difference: 100.0
             }
           },
           memory_usage_data: %CollectionData{statistics: %Statistics{}}

--- a/test/benchee/formatters/console/run_time_test.exs
+++ b/test/benchee/formatters/console/run_time_test.exs
@@ -220,7 +220,7 @@ defmodule Benchee.Formatters.Console.RunTimeTest do
 
       assert comp_header =~ ~r/Comparison/
       assert reference =~ ~r/^First\s+10 K$/m
-      assert slower =~ ~r/^Second\s+5 K\s+- 2.00x slower - \+100 ns$/m
+      assert slower =~ ~r/^Second\s+5 K\s+- 2.00x slower \+100 ns$/m
     end
 
     test "can omit the comparisons" do

--- a/test/benchee/formatters/console_test.exs
+++ b/test/benchee/formatters/console_test.exs
@@ -26,22 +26,6 @@ defmodule Benchee.Formatters.ConsoleTest do
     test "formats and prints the results right to the console" do
       scenarios = [
         %Scenario{
-          name: "Second",
-          input_name: @no_input,
-          input: @no_input,
-          run_time_data: %CollectionData{
-            statistics: %Statistics{
-              average: 200.0,
-              ips: 5_000.0,
-              std_dev_ratio: 0.1,
-              median: 195.5,
-              percentiles: %{99 => 400.1},
-              sample_size: 200
-            }
-          },
-          memory_usage_data: %CollectionData{statistics: %Statistics{}}
-        },
-        %Scenario{
           name: "First",
           input_name: @no_input,
           input: @no_input,
@@ -53,6 +37,24 @@ defmodule Benchee.Formatters.ConsoleTest do
               median: 90.0,
               percentiles: %{99 => 300.1},
               sample_size: 200
+            }
+          },
+          memory_usage_data: %CollectionData{statistics: %Statistics{}}
+        },
+        %Scenario{
+          name: "Second",
+          input_name: @no_input,
+          input: @no_input,
+          run_time_data: %CollectionData{
+            statistics: %Statistics{
+              average: 200.0,
+              ips: 5_000.0,
+              std_dev_ratio: 0.1,
+              median: 195.5,
+              percentiles: %{99 => 400.1},
+              sample_size: 200,
+              relative_more: 2.0,
+              absolute_difference: 100.0
             }
           },
           memory_usage_data: %CollectionData{statistics: %Statistics{}}
@@ -210,7 +212,9 @@ defmodule Benchee.Formatters.ConsoleTest do
               std_dev_ratio: 0.1,
               median: 195.5,
               percentiles: %{99 => 300.1},
-              sample_size: 200
+              sample_size: 200,
+              relative_more: 2.0,
+              absolute_difference: 100.0
             }
           },
           memory_usage_data: %CollectionData{statistics: %Statistics{}}
@@ -242,7 +246,9 @@ defmodule Benchee.Formatters.ConsoleTest do
               std_dev_ratio: 0.15,
               median: 395.0,
               percentiles: %{99 => 500.1},
-              sample_size: 200
+              sample_size: 200,
+              relative_more: 1.6,
+              absolute_difference: 150.0
             }
           },
           memory_usage_data: %CollectionData{statistics: %Statistics{}}
@@ -296,7 +302,9 @@ defmodule Benchee.Formatters.ConsoleTest do
               std_dev_ratio: 0.1,
               median: 195.5,
               percentiles: %{99 => 300.1},
-              sample_size: 200
+              sample_size: 200,
+              relative_more: 2.0,
+              absolute_difference: 100.0
             }
           },
           memory_usage_data: %CollectionData{statistics: %Statistics{}}

--- a/test/benchee/formatters/console_test.exs
+++ b/test/benchee/formatters/console_test.exs
@@ -70,14 +70,16 @@ defmodule Benchee.Formatters.ConsoleTest do
           )
         end)
 
-      assert output =~ ~r/First/
-      assert output =~ ~r/Second/
-      assert output =~ ~r/200/
-      assert output =~ ~r/5 K/
-      assert output =~ ~r/10.00%/
-      assert output =~ ~r/195.5/
-      assert output =~ ~r/300.1/
-      assert output =~ ~r/400.1/
+      assert output =~ "First"
+      assert output =~ "Second"
+      assert output =~ "200"
+      assert output =~ "5 K"
+      assert output =~ "10.00%"
+      assert output =~ "195.5"
+      assert output =~ "300.1"
+      assert output =~ "400.1"
+      assert output =~ "2.00x slower"
+      assert output =~ "+100 ns"
     end
   end
 
@@ -263,14 +265,14 @@ defmodule Benchee.Formatters.ConsoleTest do
       assert other_job =~ ~r/Other Job.+10.+100.+30\.00%.+98.+200\.1/
       assert job =~ ~r/Job.+5.+200.+10\.00%.+195\.5/
       ref =~ ~r/Other Job/
-      slower =~ ~r/Job.+slower/
+      slower =~ ~r/Job.+slower \+100/
 
       [input_header_2, _, other_job_2, job_2, _, ref_2, slower_2] = other_arg
       assert input_header_2 =~ "Other Arg"
       assert other_job_2 =~ ~r/Other Job.+4.+250.+31\.00%.+225\.5.+300\.1/
       assert job_2 =~ ~r/Job.+2\.5.+400.+15\.00%.+395/
       ref_2 =~ ~r/Other Job/
-      slower_2 =~ ~r/Job.+slower/
+      slower_2 =~ ~r/Job.+slower \+150/
     end
 
     test "with and without a tag" do

--- a/test/benchee/formatters/console_test.exs
+++ b/test/benchee/formatters/console_test.exs
@@ -321,6 +321,52 @@ defmodule Benchee.Formatters.ConsoleTest do
       assert comparison =~ ~r/job \(improved\)\s+ 10 K/
     end
 
+    test "Correctly displays difference even if it is negative" do
+      scenarios = [
+        %Scenario{
+          name: "job",
+          input_name: @no_input,
+          input: @no_input,
+          run_time_data: %CollectionData{
+            statistics: %Statistics{
+              average: 200.0,
+              ips: 5_000.0,
+              std_dev_ratio: 0.1,
+              median: 195.5,
+              percentiles: %{99 => 300.1},
+              sample_size: 200
+            }
+          },
+          memory_usage_data: %CollectionData{statistics: %Statistics{}}
+        },
+        %Scenario{
+          name: "job (improved)",
+          input_name: @no_input,
+          input: @no_input,
+          run_time_data: %CollectionData{
+            statistics: %Statistics{
+              average: 100.0,
+              ips: 10_000.0,
+              std_dev_ratio: 0.1,
+              median: 90.0,
+              percentiles: %{99 => 200.1},
+              sample_size: 200,
+              relative_more: 0.5,
+              relative_less: 2.0,
+              absolute_difference: -100.0
+            }
+          },
+          memory_usage_data: %CollectionData{statistics: %Statistics{}}
+        }
+      ]
+
+      [result] = Console.format(%Suite{scenarios: scenarios, configuration: @config}, @options)
+      [_, _header, _job_with_tag, _job, _, comparison, slower] = result
+
+      assert comparison =~ ~r/job\s+ 5 K$/
+      assert slower =~ ~r/job \(improved\)\s+10 K\s+- 0\.50x slower - -100 ns$/
+    end
+
     test "includes the suite's title" do
       scenarios = [
         %Scenario{

--- a/test/benchee/formatters/console_test.exs
+++ b/test/benchee/formatters/console_test.exs
@@ -364,7 +364,7 @@ defmodule Benchee.Formatters.ConsoleTest do
       [_, _header, _job_with_tag, _job, _, comparison, slower] = result
 
       assert comparison =~ ~r/job\s+ 5 K$/
-      assert slower =~ ~r/job \(improved\)\s+10 K\s+- 0\.50x slower - -100 ns$/
+      assert slower =~ ~r/job \(improved\)\s+10 K\s+- 0\.50x slower -100 ns$/
     end
 
     test "includes the suite's title" do

--- a/test/benchee/statistics_test.exs
+++ b/test/benchee/statistics_test.exs
@@ -211,8 +211,8 @@ defmodule Benchee.StatistcsTest do
       assert run_time_stats_1.average == 0.0
       assert run_time_stats_2.sample_size == 5
 
-      assert run_time_stats_2.relative_more == :infinity
-      assert run_time_stats_2.relative_less == :infinity
+      assert run_time_stats_2.relative_more == 1.0
+      assert run_time_stats_2.relative_less == 1.0
       assert run_time_stats_2.absolute_difference == 0.0
     end
 

--- a/test/benchee_test.exs
+++ b/test/benchee_test.exs
@@ -768,12 +768,14 @@ defmodule BencheeTest do
       benches = %{
         "delete old" => fn {kv, key} -> BenchKeyword.delete_v0(kv, key) end,
         "delete reverse" => fn {kv, key} -> BenchKeyword.delete_v2(kv, key) end,
-        "delete keymember reverse" => fn {kv, key} -> BenchKeyword.delete_v3(kv, key) end
+        "delete keymember reverse" => fn {kv, key} -> BenchKeyword.delete_v3(kv, key) end,
+        "delete throw" => fn {kv, key} -> BenchKeyword.delete_v1(kv, key) end
       }
 
       inputs = %{
         "large miss" => {Enum.map(1..100, &{:"k#{&1}", &1}), :k101},
-        "large hit" => {Enum.map(1..100, &{:"k#{&1}", &1}), :k100}
+        "large hit" => {Enum.map(1..100, &{:"k#{&1}", &1}), :k100},
+        "small miss" => {Enum.map(1..10, &{:"k#{&1}", &1}), :k11}
       }
 
       output =
@@ -796,6 +798,9 @@ defmodule BencheeTest do
       assert output =~ "large hit"
       # Byte
       assert output =~ "B"
+
+      assert output =~ "1.00x memory"
+      assert output =~ "infinity x memo"
     end
   end
 

--- a/test/benchee_test.exs
+++ b/test/benchee_test.exs
@@ -186,7 +186,6 @@ defmodule BencheeTest do
 
     assert output =~ ~r/fast/
     assert output =~ ~r/unreliable/
-    assert output =~ ~r/^Constant\s+\d+.+\s+[0-2]\.\d+ ns/m
   end
 
   @tag :needs_fast_function_repetition
@@ -804,7 +803,7 @@ defmodule BencheeTest do
     end
   end
 
-  @slower_regex "\\s+- \\d+\\.\\d+x slower - \\+\\d+\\.\\d+.+"
+  @slower_regex "\\s+- \\d+\\.\\d+x slower - \\+\\d+(\\.\\d+)?.+"
   defp readme_sample_asserts(output, tag_string \\ "") do
     assert output =~ "warmup: 5 ms"
     assert output =~ "time: 10 ms"

--- a/test/benchee_test.exs
+++ b/test/benchee_test.exs
@@ -800,11 +800,11 @@ defmodule BencheeTest do
       assert output =~ "B"
 
       assert output =~ "1.00x memory"
-      assert output =~ "infinity x memo"
+      assert output =~ "∞ x memo"
     end
   end
 
-  @slower_regex "\\s+- \\d+\\.\\d+x slower"
+  @slower_regex "\\s+- \\d+\\.\\d+x slower - \\+\\d+\\.\\d+.+"
   defp readme_sample_asserts(output, tag_string \\ "") do
     assert output =~ "warmup: 5 ms"
     assert output =~ "time: 10 ms"
@@ -820,7 +820,7 @@ defmodule BencheeTest do
 
     # In windows time resolution seems to be milliseconds, hence even
     # standard examples produce a fast warning.
-    # So we skip this basic is everything going fine test on windows
+    # So we skip this "basically everything is going fine" test on windows
     unless windows?(), do: refute(output =~ ~r/fast/i)
   end
 

--- a/test/benchee_test.exs
+++ b/test/benchee_test.exs
@@ -803,7 +803,7 @@ defmodule BencheeTest do
     end
   end
 
-  @slower_regex "\\s+- \\d+\\.\\d+x slower - \\+\\d+(\\.\\d+)?.+"
+  @slower_regex "\\s+- \\d+\\.\\d+x slower \\+\\d+(\\.\\d+)?.+"
   defp readme_sample_asserts(output, tag_string \\ "") do
     assert output =~ "warmup: 5 ms"
     assert output =~ "time: 10 ms"

--- a/test/benchee_test.exs
+++ b/test/benchee_test.exs
@@ -422,7 +422,7 @@ defmodule BencheeTest do
     assert length(occurences) == 3
   end
 
-  test "inputs can also be a list of 2-tuples" do
+  test "inputs can also be a list of 2-tuples and it then keeps the order" do
     output =
       capture_io(fn ->
         map_fun = fn i -> [i, i * i] end
@@ -592,20 +592,34 @@ defmodule BencheeTest do
     end)
   end
 
-  test "does not blow up setting all times to 0 and never executes a function" do
-    output =
-      capture_io(fn ->
-        Benchee.run(
-          %{
-            "never execute me" => fn -> raise "BOOOOM" end
-          },
-          time: 0,
-          warmup: 0,
-          memory_time: 0
-        )
-      end)
+  describe "edge cases" do
+    test "does not blow up setting all times to 0 and never executes a function" do
+      output =
+        capture_io(fn ->
+          Benchee.run(
+            %{
+              "never execute me" => fn -> raise "BOOOOM" end
+            },
+            time: 0,
+            warmup: 0,
+            memory_time: 0
+          )
+        end)
 
-    refute output =~ "never execute me"
+      refute output =~ "never execute me"
+    end
+
+    test "does not blow up if nothing is specified" do
+      output =
+        capture_io(fn ->
+          Benchee.run(
+            %{},
+            @test_configuration
+          )
+        end)
+
+      refute output =~ "Benchmarking"
+    end
   end
 
   describe "save & load" do

--- a/test/support/bench_keyword.ex
+++ b/test/support/bench_keyword.ex
@@ -11,6 +11,24 @@ defmodule BenchKeyword do
     :lists.filter(fn {k, _} -> k != key end, keywords)
   end
 
+  def delete_v1(keywords, key) when is_list(keywords) and is_atom(key) do
+    do_delete(keywords, key, _deleted? = false)
+  catch
+    :not_deleted -> keywords
+  end
+
+  defp do_delete([{key, _} | rest], key, _deleted?),
+    do: do_delete(rest, key, true)
+
+  defp do_delete([{_, _} = pair | rest], key, deleted?),
+    do: [pair | do_delete(rest, key, deleted?)]
+
+  defp do_delete([], _key, _deleted? = true),
+    do: []
+
+  defp do_delete([], _key, _deleted? = false),
+    do: throw(:not_deleted)
+
   def delete_v2(keywords, key) when is_list(keywords) and is_atom(key) do
     delete_v2_key(keywords, key, [])
   end


### PR DESCRIPTION
This is done for 2 reasons:
1. support a new feature I really want to have before 1.0/as a
  little migration bait which is supposed to show the absolute
  difference to the reference scenario/fastest scenario. This
  is good to put performance gains into perspective. It's
  great if something is 100 times as fast, but if it only
  gains me 1 ms in a program that takes 100ms then it's probably
  not worth it
2. centralize the calculation of the multiplicator / lesser / more
  thing so that not every formatter has to implement that
  popular calculation by themselves. This also revealed an
  interesting case that I think we're not handling correctly in
  the formatters yet that happens when the average is 0.

It took more code than I thought it'd but looking at it I also
wouldn't know where to cut it.

Input welcome specifically on the struct field names, half-way
unsure there. I didn't document them yet as the other PR isn't
merged yet.

edit: now also includes output which you can see in a comment below