### PR TITLE
Fix memory display extended statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.1 (2019-04-09)
+
+### Bugfixes (User Facing)
+* When memory measurements were actually different extended statistics was displayed although the option was not provided. Now correctly only displayed if the option is provided and values actually had variance.
+
 ## 1.0.0 (2019-03-28)
 
 It's 0.99.0 without the deprecation warnings. Specifically:

--- a/lib/benchee/formatters/console/memory.ex
+++ b/lib/benchee/formatters/console/memory.ex
@@ -254,16 +254,18 @@ defmodule Benchee.Formatters.Console.Memory do
     Memory.format({Memory.scale(memory, unit), unit})
   end
 
-  defp extended_statistics_report(_, _, _, %{extended_statistics: false}, _), do: []
+  defp extended_statistics_report(scenarios, units, label_width, config, hide_statistics)
   defp extended_statistics_report(_, _, _, _, true), do: []
 
-  defp extended_statistics_report(scenarios, units, label_width, _config, _hide_statistics) do
+  defp extended_statistics_report(scenarios, units, label_width, %{extended_statistics: true}, _) do
     [
       Helpers.descriptor("Extended statistics"),
       extended_column_descriptors(label_width)
       | extended_statistics(scenarios, units, label_width)
     ]
   end
+
+  defp extended_statistics_report(_, _, _, _, _), do: []
 
   defp extended_column_descriptors(label_width) do
     "\n~*s~*s~*s~*s~*s\n"

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Benchee.Mixfile do
   use Mix.Project
 
-  @version "1.0.0"
+  @version "1.0.1"
 
   def project do
     [

--- a/samples/memory_changing.exs
+++ b/samples/memory_changing.exs
@@ -1,0 +1,12 @@
+# random by design so that we get some memory statistics
+Benchee.run(
+  %{
+    "Enum.to_list" => fn range -> Enum.to_list(range) end,
+    "Enum.into" => fn range -> Enum.into(range, []) end
+  },
+  # formatters: [{Benchee.Formatters.Console, extended_statistics: true}],
+  before_each: fn _ -> 0..(:rand.uniform(1_000) + 1000) end,
+  warmup: 0.1,
+  time: 0.1,
+  memory_time: 1
+)

--- a/test/benchee/formatters/console/memory_test.exs
+++ b/test/benchee/formatters/console/memory_test.exs
@@ -330,6 +330,44 @@ defmodule Benchee.Formatters.Console.MemoryTest do
       assert result2 =~ "201.20"
     end
 
+    test "doesn't display extended statistics if extended_statistics isn't specified" do
+      scenarios = [
+        %Scenario{
+          name: "First job",
+          memory_usage_data: %CollectionData{
+            statistics: %Statistics{
+              average: 200.0,
+              ips: 5_000.0,
+              std_dev_ratio: 0.1,
+              median: 195.5,
+              percentiles: %{99 => 300.1},
+              minimum: 111.1,
+              maximum: 333.3,
+              mode: 201.2,
+              sample_size: 50_000
+            }
+          },
+          run_time_data: %CollectionData{statistics: %Statistics{average: 100.0, ips: 1_000.0}}
+        }
+      ]
+
+      params = %{
+        unit_scaling: :best
+      }
+
+      output = scenarios |> Memory.format_scenarios(params) |> Enum.join("")
+
+      refute output =~ "Extended statistics: "
+      refute output =~ "minimum"
+      refute output =~ "maximum"
+      refute output =~ "sample size"
+      refute output =~ "mode"
+      refute output =~ "111.10"
+      refute output =~ "333.30"
+      refute output =~ "50 K"
+      refute output =~ "201.20"
+    end
+
     test "does nothing when there's no statistics to format" do
       scenarios = [
         %Scenario{memory_usage_data: %CollectionData{statistics: %Statistics{sample_size: 0}}}


### PR DESCRIPTION
Always displayed extended statistics although it shouldn't