### PR TITLE
Extract Statistex from benchee

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
   - travis_wait mix dialyzer --plt
 script:
   - mix credo --strict
-  - mix format --check-formatted
+  - if [[ "$TRAVIS_ELIXIR_VERSION" == "1.8"* ]]; then mix format --check-formatted; fi
   - mix dialyzer --halt-exit-status
   - mix coveralls.travis
 after_script:

--- a/lib/benchee/benchmark/function_call_overhead.ex
+++ b/lib/benchee/benchmark/function_call_overhead.ex
@@ -1,0 +1,54 @@
+defmodule Benchee.Benchmark.FunctionCallOverhead do
+  @moduledoc false
+
+  alias Benchee.Benchmark.Collect.Time
+  alias Benchee.Conversion
+
+  @overhead_determination_time Conversion.Duration.convert_value({0.01, :second}, :nanosecond)
+
+  # Compute the function call overhead on the current system
+  #
+  # You might wonder why this isn't done simply through using our existing infrastructure
+  # and just run it with Scenario, Context etc. - in fact that's how it used to be,
+  # but it meant that we'd pass half-baked scenarios to functions causing dialyzer to complain,
+  # as well as running for a lot more code than we strictly need to like the
+  # `determine_n_times` code that we should rather not go through as it changes
+  # what this function does.
+  # This also gives us a way to make sure we definitely take at least one measurement.
+  @spec measure() :: number
+  def measure do
+    # just the fastest function one can think of...
+    overhead_function = fn -> nil end
+
+    _ = warmup(overhead_function)
+    run_times = run(overhead_function)
+    Statistex.median(run_times)
+  end
+
+  defp warmup(function) do
+    run_for(function, @overhead_determination_time / 2)
+  end
+
+  defp run(function) do
+    run_for(function, @overhead_determination_time)
+  end
+
+  defp run_for(function, run_time) do
+    end_time = current_time() + run_time
+
+    do_run(function, [], end_time)
+  end
+
+  @spec do_run((() -> any), [number], number) :: [number, ...]
+  defp do_run(function, durations, end_time) do
+    {duration, _} = Time.collect(function)
+
+    if current_time() < end_time do
+      do_run(function, [duration | durations], end_time)
+    else
+      durations
+    end
+  end
+
+  defp current_time, do: :erlang.system_time(:nano_seconds)
+end

--- a/lib/benchee/benchmark/repeated_measurement.ex
+++ b/lib/benchee/benchmark/repeated_measurement.ex
@@ -27,7 +27,7 @@ defmodule Benchee.Benchmark.RepeatedMeasurement do
 
   @minimum_execution_time 10
   @times_multiplier 10
-  @spec determine_n_times(Scenario.t(), any, boolean, module) ::
+  @spec determine_n_times(Scenario.t(), ScenarioContext.t(), boolean, module) ::
           {pos_integer, number}
   def determine_n_times(
         scenario,

--- a/lib/benchee/benchmark/repeated_measurement.ex
+++ b/lib/benchee/benchmark/repeated_measurement.ex
@@ -27,8 +27,8 @@ defmodule Benchee.Benchmark.RepeatedMeasurement do
 
   @minimum_execution_time 10
   @times_multiplier 10
-  @spec determine_n_times(Scenario.t(), ScenarioContext.t(), boolean, module) ::
-          {pos_integer, any}
+  @spec determine_n_times(Scenario.t(), any, boolean, module) ::
+          {pos_integer, number}
   def determine_n_times(
         scenario,
         scenario_context = %ScenarioContext{

--- a/lib/benchee/benchmark/runner.ex
+++ b/lib/benchee/benchmark/runner.ex
@@ -66,7 +66,7 @@ defmodule Benchee.Benchmark.Runner do
     }
 
     {run_times, []} = measure_scenario(scenario, scenario_context)
-    %{50 => median} = Statistics.Percentile.percentiles(run_times, 50)
+    %{50 => median} = Statistex.percentiles(run_times, [50])
 
     median
   end

--- a/lib/benchee/benchmark/runner.ex
+++ b/lib/benchee/benchmark/runner.ex
@@ -4,7 +4,7 @@ defmodule Benchee.Benchmark.Runner do
   # This module actually runs our benchmark scenarios, adding information about
   # run time and memory usage to each scenario.
 
-  alias Benchee.{Benchmark, Configuration, Conversion, Scenario, Statistics, Utility.Parallel}
+  alias Benchee.{Benchmark, Configuration, Conversion, Scenario, Utility.Parallel}
   alias Benchmark.{Collect, Hooks, RepeatedMeasurement, ScenarioContext}
 
   @doc """

--- a/lib/benchee/benchmark/runner.ex
+++ b/lib/benchee/benchmark/runner.ex
@@ -66,7 +66,7 @@ defmodule Benchee.Benchmark.Runner do
     }
 
     {run_times, []} = measure_scenario(scenario, scenario_context)
-    %{50 => median} = Statistex.percentiles(run_times, [50])
+    %{50 => median} = Statistex.percentiles(run_times, 50)
 
     median
   end

--- a/lib/benchee/benchmark/scenario_context.ex
+++ b/lib/benchee/benchmark/scenario_context.ex
@@ -21,6 +21,6 @@ defmodule Benchee.Benchmark.ScenarioContext do
           end_time: pos_integer | nil,
           scenario_input: any,
           num_iterations: pos_integer,
-          function_call_overhead: pos_integer
+          function_call_overhead: non_neg_integer
         }
 end

--- a/lib/benchee/statistics.ex
+++ b/lib/benchee/statistics.ex
@@ -192,6 +192,12 @@ defmodule Benchee.Statistics do
     }
   end
 
+  defp calculate_statistics([], _) do
+    %__MODULE__{
+      sample_size: 0
+    }
+  end
+
   defp calculate_statistics(samples, percentiles) do
     samples
     |> Statistex.statistics(percentiles: percentiles)

--- a/lib/benchee/statistics.ex
+++ b/lib/benchee/statistics.ex
@@ -201,8 +201,8 @@ defmodule Benchee.Statistics do
   defp convert_from_statistex(statistex_statistics) do
     %__MODULE__{
       average: statistex_statistics.average,
-      std_dev: statistex_statistics.std_dev,
-      std_dev_ratio: statistex_statistics.std_dev_ratio,
+      std_dev: statistex_statistics.standard_deviation,
+      std_dev_ratio: statistex_statistics.standard_deviation_ratio,
       median: statistex_statistics.median,
       percentiles: statistex_statistics.percentiles,
       mode: statistex_statistics.mode,

--- a/lib/benchee/statistics.ex
+++ b/lib/benchee/statistics.ex
@@ -6,10 +6,8 @@ defmodule Benchee.Statistics do
   See `statistics/1` for a breakdown of the included statistics.
   """
 
-  alias Benchee.{Conversion.Duration, Suite, Utility.Parallel}
+  alias Benchee.{CollectionData, Conversion.Duration, Scenario, Suite, Utility.Parallel}
 
-  alias Benchee.Statistics.Mode
-  alias Benchee.Statistics.Percentile
   require Integer
 
   defstruct [
@@ -163,69 +161,55 @@ defmodule Benchee.Statistics do
 
   """
   @spec statistics(Suite.t()) :: Suite.t()
-  def statistics(suite = %Suite{scenarios: scenarios}) do
-    config = suite.configuration
+  def statistics(suite) do
+    percentiles = suite.configuration.percentiles
 
-    scenarios_with_statistics = calculate_per_scenario_statistics(scenarios, config)
-
-    %Suite{suite | scenarios: scenarios_with_statistics}
-  end
-
-  defp calculate_per_scenario_statistics(scenarios, config) do
-    percentiles = Enum.uniq([50 | config.percentiles])
-
-    Parallel.map(scenarios, fn scenario ->
-      run_time_stats = scenario.run_time_data.samples |> job_statistics(percentiles) |> add_ips
-      memory_stats = job_statistics(scenario.memory_usage_data.samples, percentiles)
-
-      %{
-        scenario
-        | run_time_data: %{scenario.run_time_data | statistics: run_time_stats},
-          memory_usage_data: %{scenario.memory_usage_data | statistics: memory_stats}
-      }
+    update_in(suite.scenarios, fn scenarios ->
+      Parallel.map(scenarios, fn scenario ->
+        calculate_scenario_statistics(scenario, percentiles)
+      end)
     end)
   end
 
-  @spec job_statistics(samples, list) :: __MODULE__.t()
-  defp job_statistics([], _) do
-    %__MODULE__{sample_size: 0}
-  end
+  defp calculate_scenario_statistics(scenario, percentiles) do
+    run_time_stats =
+      scenario.run_time_data.samples
+      |> calculate_statistics(percentiles)
+      |> add_ips
 
-  defp job_statistics(samples, percentiles) do
-    total = Enum.sum(samples)
-    num_iterations = length(samples)
-    average = total / num_iterations
-    deviation = standard_deviation(samples, average, num_iterations)
-    standard_dev_ratio = if average == 0, do: 0, else: deviation / average
-    percentiles = Percentile.percentiles(samples, percentiles)
-    median = Map.fetch!(percentiles, 50)
-    mode = Mode.mode(samples)
-    minimum = Enum.min(samples)
-    maximum = Enum.max(samples)
+    memory_stats = calculate_statistics(scenario.memory_usage_data.samples, percentiles)
 
-    %__MODULE__{
-      average: average,
-      std_dev: deviation,
-      std_dev_ratio: standard_dev_ratio,
-      median: median,
-      percentiles: percentiles,
-      mode: mode,
-      minimum: minimum,
-      maximum: maximum,
-      sample_size: num_iterations
+    %Scenario{
+      scenario
+      | run_time_data: %CollectionData{
+          scenario.run_time_data
+          | statistics: run_time_stats
+        },
+        memory_usage_data: %CollectionData{
+          scenario.memory_usage_data
+          | statistics: memory_stats
+        }
     }
   end
 
-  defp standard_deviation(_samples, _average, 1), do: 0
+  defp calculate_statistics(samples, percentiles) do
+    samples
+    |> Statistex.statistics(percentiles: percentiles)
+    |> convert_from_statistex
+  end
 
-  defp standard_deviation(samples, average, sample_size) do
-    total_variance =
-      Enum.reduce(samples, 0, fn sample, total ->
-        total + :math.pow(sample - average, 2)
-      end)
-
-    variance = total_variance / (sample_size - 1)
-    :math.sqrt(variance)
+  defp convert_from_statistex(statistex_statistics) do
+    %__MODULE__{
+      average: statistex_statistics.average,
+      std_dev: statistex_statistics.std_dev,
+      std_dev_ratio: statistex_statistics.std_dev_ratio,
+      median: statistex_statistics.median,
+      percentiles: statistex_statistics.percentiles,
+      mode: statistex_statistics.mode,
+      minimum: statistex_statistics.minimum,
+      maximum: statistex_statistics.maximum,
+      sample_size: statistex_statistics.sample_size
+    }
   end
 
   defp add_ips(statistics = %__MODULE__{sample_size: 0}), do: statistics

--- a/lib/statistex.ex
+++ b/lib/statistex.ex
@@ -46,7 +46,7 @@ defmodule Statistex do
   @typedoc """
   The samples to compute statistics from.
   """
-  @type samples :: [sample, ...]
+  @type samples :: [sample]
 
   @typedoc """
   A single sample/
@@ -77,7 +77,7 @@ defmodule Statistex do
   @typedoc """
   The percentiles map returned by `percentiles/2`.
   """
-  @type percentiles :: %{optional(number()) => float}
+  @type percentiles :: %{number() => float}
 
   @doc """
   Calculate all statistics Statistex offers for a given list of numbers.

--- a/lib/statistex.ex
+++ b/lib/statistex.ex
@@ -1,0 +1,138 @@
+defmodule Statistex do
+  @moduledoc """
+  Statistics related functionality that is meant to take the raw benchmark data
+  and then compute statistics like the average and the standard deviation etc.
+
+  See `statistics/1` for a breakdown of the included statistics.
+  """
+
+  alias Statistex.{Mode, Percentile}
+  require Integer
+
+  defstruct [
+    :average,
+    :std_dev,
+    :std_dev_ratio,
+    :median,
+    :percentiles,
+    :mode,
+    :minimum,
+    :maximum,
+    :relative_more,
+    :relative_less,
+    :absolute_difference,
+    sample_size: 0
+  ]
+
+  @typedoc """
+  All the statistics `statistics/1` computes from the samples.
+
+  Overview of all the statistics benchee currently provides:
+
+    * average       - average run time of the job in μs (the lower the better)
+    * ips           - iterations per second, how often can the given function be
+      executed within one second (the higher the better)
+    * std_dev       - standard deviation, a measurement how much results vary
+      (the higher the more the results vary)
+    * std_dev_ratio - standard deviation expressed as how much it is relative to
+      the average
+    * std_dev_ips   - the absolute standard deviation of iterations per second
+      (= ips * std_dev_ratio)
+    * median        - when all measured times are sorted, this is the middle
+      value (or average of the two middle values when the number of times is
+      even). More stable than the average and somewhat more likely to be a
+      typical value you see.
+    * percentiles   - a map of percentile ranks. These are the values below
+      which x% of the run times lie. For example, 99% of run times are shorter
+      than the 99th percentile (99th %) rank.
+      is a value for which 99% of the run times are shorter.
+    * mode          - the run time(s) that occur the most. Often one value, but
+      can be multiple values if they occur the same amount of times. If no value
+      occurs at least twice, this value will be nil.
+    * minimum       - the smallest sample measured for the scenario
+    * maximum       - the biggest sample measured for the scenario
+    * relative_more - relative to the reference (usually the fastest scenario) how much more
+      was the average of this scenario. E.g. for reference at 100, this scenario 200 then it
+      is 2.0.
+    * relative_less - relative to the reference (usually the fastest scenario) how much less
+      was the average of this scenario. E.g. for reference at 100, this scenario 200 then it
+      is 0.5.
+    * absolute_difference - relative to the reference (usually the fastest scenario) what is
+      the difference of the averages of the scenarios. e.g. for reference at 100, this
+      scenario 200 then it is 100.
+    * sample_size   - the number of run time measurements taken
+  """
+  @type t :: %__MODULE__{
+          average: float,
+          std_dev: float,
+          std_dev_ratio: float,
+          median: number,
+          percentiles: %{number => float},
+          mode: Statistex.Mode.mode(),
+          minimum: number,
+          maximum: number,
+          relative_more: float | nil | :infinity,
+          relative_less: float | nil | :infinity,
+          absolute_difference: float | nil,
+          sample_size: non_neg_integer
+        }
+
+  @typedoc """
+  The samples a `Benchee.Collect` collected to compute statistics from.
+  """
+  @type samples :: [number]
+
+  @type configuration :: keyword
+  @doc """
+  WIP
+  """
+  @spec statistics(samples, configuration) :: t()
+  def statistics(samples, configuration \\ [])
+
+  def statistics([], _) do
+    %__MODULE__{sample_size: 0}
+  end
+
+  def statistics(samples, configuration) do
+    total = Enum.sum(samples)
+    num_iterations = length(samples)
+    average = total / num_iterations
+    deviation = standard_deviation(samples, average, num_iterations)
+    standard_dev_ratio = if average == 0, do: 0, else: deviation / average
+
+    percentiles = Keyword.get(configuration, :percentiles, [])
+    percentiles = Enum.uniq([50 | percentiles])
+
+    percentiles = Percentile.percentiles(samples, percentiles)
+    median = Map.fetch!(percentiles, 50)
+    mode = Mode.mode(samples)
+    minimum = Enum.min(samples)
+    maximum = Enum.max(samples)
+
+    %__MODULE__{
+      average: average,
+      std_dev: deviation,
+      std_dev_ratio: standard_dev_ratio,
+      median: median,
+      percentiles: percentiles,
+      mode: mode,
+      minimum: minimum,
+      maximum: maximum,
+      sample_size: num_iterations
+    }
+  end
+
+  defdelegate percentiles(samples, percentiles), to: Percentile
+
+  defp standard_deviation(_samples, _average, 1), do: 0
+
+  defp standard_deviation(samples, average, sample_size) do
+    total_variance =
+      Enum.reduce(samples, 0, fn sample, total ->
+        total + :math.pow(sample - average, 2)
+      end)
+
+    variance = total_variance / (sample_size - 1)
+    :math.sqrt(variance)
+  end
+end

--- a/lib/statistex/mode.ex
+++ b/lib/statistex/mode.ex
@@ -1,26 +1,7 @@
 defmodule Statistex.Mode do
   @moduledoc false
 
-  @typedoc """
-  Careful with the mode, might be multiple values, one value or nothing.😱
-  """
-  @type mode :: [Statistex.sample()] | Statistex.sample() | nil
-
-  @doc """
-      iex> Statistex.Mode.mode([5, 3, 4, 5, 1, 3, 1, 3])
-      3
-
-      iex> Statistex.Mode.mode([])
-      nil
-
-      iex> Statistex.Mode.mode([1, 2, 3, 4, 5])
-      nil
-
-      iex> mode = Statistex.Mode.mode([5, 3, 4, 5, 1, 3, 1])
-      iex> Enum.sort(mode)
-      [1, 3, 5]
-  """
-  @spec mode(Statistex.samples()) :: mode()
+  @spec mode(Statistex.samples()) :: Statistex.mode()
   def(mode(samples)) do
     samples
     |> Enum.reduce(%{}, fn sample, counts ->

--- a/lib/statistex/mode.ex
+++ b/lib/statistex/mode.ex
@@ -2,7 +2,14 @@ defmodule Statistex.Mode do
   @moduledoc false
 
   @spec mode(Statistex.samples()) :: Statistex.mode()
-  def(mode(samples)) do
+  def mode([]) do
+    raise(
+      ArgumentError,
+      "Passed an empty list ([]) to calculate statistics from, please pass a list containing at least on number."
+    )
+  end
+
+  def mode(samples) do
     samples
     |> Enum.reduce(%{}, fn sample, counts ->
       Map.update(counts, sample, 1, fn old_value -> old_value + 1 end)

--- a/lib/statistex/mode.ex
+++ b/lib/statistex/mode.ex
@@ -1,23 +1,26 @@
-defmodule Benchee.Statistics.Mode do
+defmodule Statistex.Mode do
   @moduledoc false
 
-  alias Benchee.Statistics
+  @typedoc """
+  Careful with the mode, might be multiple values, one value or nothing.😱
+  """
+  @type mode :: [number] | number | nil
 
   @doc """
-      iex> Benchee.Statistics.Mode.mode([5, 3, 4, 5, 1, 3, 1, 3])
+      iex> Statistex.Mode.mode([5, 3, 4, 5, 1, 3, 1, 3])
       3
 
-      iex> Benchee.Statistics.Mode.mode([])
+      iex> Statistex.Mode.mode([])
       nil
 
-      iex> Benchee.Statistics.Mode.mode([1, 2, 3, 4, 5])
+      iex> Statistex.Mode.mode([1, 2, 3, 4, 5])
       nil
 
-      iex> mode = Benchee.Statistics.Mode.mode([5, 3, 4, 5, 1, 3, 1])
+      iex> mode = Statistex.Mode.mode([5, 3, 4, 5, 1, 3, 1])
       iex> Enum.sort(mode)
       [1, 3, 5]
   """
-  @spec mode(Statistics.samples()) :: Statistics.mode()
+  @spec mode(Statistex.samples()) :: mode()
   def(mode(samples)) do
     samples
     |> Enum.reduce(%{}, fn sample, counts ->

--- a/lib/statistex/mode.ex
+++ b/lib/statistex/mode.ex
@@ -4,7 +4,7 @@ defmodule Statistex.Mode do
   @typedoc """
   Careful with the mode, might be multiple values, one value or nothing.😱
   """
-  @type mode :: [number] | number | nil
+  @type mode :: [Statistex.sample()] | Statistex.sample() | nil
 
   @doc """
       iex> Statistex.Mode.mode([5, 3, 4, 5, 1, 3, 1, 3])

--- a/lib/statistex/percentile.ex
+++ b/lib/statistex/percentile.ex
@@ -1,46 +1,10 @@
 defmodule Statistex.Percentile do
   @moduledoc false
 
-  @type percentile :: float()
-  @type percentiles :: %{optional(number()) => percentile()}
+  @spec percentiles(Statistex.samples(), number | [number, ...]) ::
+          Statistex.percentiles() | Statistex.empty_list_error()
+  def percentiles([], _), do: {:error, :empty_list}
 
-  @doc """
-  Calculates the value at the `percentile_rank`-th percentile.
-
-  Think of this as the
-  value below which `percentile_rank` percent of the samples lie. For example,
-  if `Statistex.Percentile.percentile(samples, 99)` == 123.45,
-  99% of samples are less than 123.45.
-
-  Passing a number for `percentile_rank` calculates a single percentile.
-  Passing a list of numbers calculates multiple percentiles, and returns them
-  as a map like %{90 => 45.6, 99 => 78.9}, where the keys are the percentile
-  numbers, and the values are the percentile values.
-
-  ## Examples
-
-  iex> Statistex.Percentile.percentiles([5, 3, 4, 5, 1, 3, 1, 3], 12.5)
-  %{12.5 => 1.0}
-
-  iex> Statistex.Percentile.percentiles([5, 3, 4, 5, 1, 3, 1, 3], [50])
-  %{50 => 3.0}
-
-  iex> Statistex.Percentile.percentiles([5, 3, 4, 5, 1, 3, 1, 3], [75])
-  %{75 => 4.75}
-
-  iex> Statistex.Percentile.percentiles([5, 3, 4, 5, 1, 3, 1, 3], 99)
-  %{99 => 5.0}
-
-  iex> Statistex.Percentile.percentiles([5, 3, 4, 5, 1, 3, 1, 3], [50, 75, 99])
-  %{50 => 3.0, 75 => 4.75, 99 => 5.0}
-
-  iex> Statistex.Percentile.percentiles([5, 3, 4, 5, 1, 3, 1, 3], 100)
-  ** (ArgumentError) percentile must be between 0 and 100, got: 100
-
-  iex> Statistex.Percentile.percentiles([5, 3, 4, 5, 1, 3, 1, 3], 0)
-  ** (ArgumentError) percentile must be between 0 and 100, got: 0
-  """
-  @spec percentiles(Statistex.samples(), number | [number()]) :: percentiles
   def percentiles(samples, percentile_ranks) do
     number_of_samples = length(samples)
     sorted_samples = Enum.sort(samples)

--- a/lib/statistex/percentile.ex
+++ b/lib/statistex/percentile.ex
@@ -1,13 +1,15 @@
-defmodule Benchee.Statistics.Percentile do
+defmodule Statistex.Percentile do
   @moduledoc false
 
   @type percentile :: float()
   @type percentiles :: %{optional(number()) => percentile()}
 
   @doc """
-  Calculates the value at the `percentile_rank`-th percentile. Think of this as the
+  Calculates the value at the `percentile_rank`-th percentile.
+
+  Think of this as the
   value below which `percentile_rank` percent of the samples lie. For example,
-  if `Benchee.Statistics.Percentile.percentile(samples, 99)` == 123.45,
+  if `Statistex.Percentile.percentile(samples, 99)` == 123.45,
   99% of samples are less than 123.45.
 
   Passing a number for `percentile_rank` calculates a single percentile.
@@ -17,28 +19,28 @@ defmodule Benchee.Statistics.Percentile do
 
   ## Examples
 
-  iex> Benchee.Statistics.Percentile.percentiles([5, 3, 4, 5, 1, 3, 1, 3], 12.5)
+  iex> Statistex.Percentile.percentiles([5, 3, 4, 5, 1, 3, 1, 3], 12.5)
   %{12.5 => 1.0}
 
-  iex> Benchee.Statistics.Percentile.percentiles([5, 3, 4, 5, 1, 3, 1, 3], [50])
+  iex> Statistex.Percentile.percentiles([5, 3, 4, 5, 1, 3, 1, 3], [50])
   %{50 => 3.0}
 
-  iex> Benchee.Statistics.Percentile.percentiles([5, 3, 4, 5, 1, 3, 1, 3], [75])
+  iex> Statistex.Percentile.percentiles([5, 3, 4, 5, 1, 3, 1, 3], [75])
   %{75 => 4.75}
 
-  iex> Benchee.Statistics.Percentile.percentiles([5, 3, 4, 5, 1, 3, 1, 3], 99)
+  iex> Statistex.Percentile.percentiles([5, 3, 4, 5, 1, 3, 1, 3], 99)
   %{99 => 5.0}
 
-  iex> Benchee.Statistics.Percentile.percentiles([5, 3, 4, 5, 1, 3, 1, 3], [50, 75, 99])
+  iex> Statistex.Percentile.percentiles([5, 3, 4, 5, 1, 3, 1, 3], [50, 75, 99])
   %{50 => 3.0, 75 => 4.75, 99 => 5.0}
 
-  iex> Benchee.Statistics.Percentile.percentiles([5, 3, 4, 5, 1, 3, 1, 3], 100)
+  iex> Statistex.Percentile.percentiles([5, 3, 4, 5, 1, 3, 1, 3], 100)
   ** (ArgumentError) percentile must be between 0 and 100, got: 100
 
-  iex> Benchee.Statistics.Percentile.percentiles([5, 3, 4, 5, 1, 3, 1, 3], 0)
+  iex> Statistex.Percentile.percentiles([5, 3, 4, 5, 1, 3, 1, 3], 0)
   ** (ArgumentError) percentile must be between 0 and 100, got: 0
   """
-  @spec percentiles([number()], number | [number()]) :: percentiles
+  @spec percentiles(Statistex.samples(), number | [number()]) :: percentiles
   def percentiles(samples, percentile_ranks) do
     number_of_samples = length(samples)
     sorted_samples = Enum.sort(samples)

--- a/lib/statistex/percentile.ex
+++ b/lib/statistex/percentile.ex
@@ -2,8 +2,13 @@ defmodule Statistex.Percentile do
   @moduledoc false
 
   @spec percentiles(Statistex.samples(), number | [number, ...]) ::
-          Statistex.percentiles() | Statistex.empty_list_error()
-  def percentiles([], _), do: {:error, :empty_list}
+          Statistex.percentiles()
+  def percentiles([], _) do
+    raise(
+      ArgumentError,
+      "Passed an empty list ([]) to calculate statistics from, please pass a list containing at least on number."
+    )
+  end
 
   def percentiles(samples, percentile_ranks) do
     number_of_samples = length(samples)

--- a/test/benchee/statistics/mode_test.exs
+++ b/test/benchee/statistics/mode_test.exs
@@ -1,4 +1,0 @@
-defmodule Benchee.Statistics.ModeTest do
-  use ExUnit.Case, async: true
-  doctest Benchee.Statistics.Mode
-end

--- a/test/benchee/statistics_test.exs
+++ b/test/benchee/statistics_test.exs
@@ -86,37 +86,6 @@ defmodule Benchee.StatistcsTest do
       sample_2_asserts(stats_2_2)
     end
 
-    @mode_sample [55, 40, 67, 55, 44, 40, 10, 8, 55, 90, 67]
-    test "mode is calculated correctly" do
-      scenarios = [
-        %Scenario{
-          run_time_data: %CollectionData{samples: @mode_sample},
-          memory_usage_data: %CollectionData{samples: @mode_sample}
-        }
-      ]
-
-      suite = Statistics.statistics(%Suite{scenarios: scenarios})
-
-      [%Scenario{run_time_data: %CollectionData{statistics: stats}}] = suite.scenarios
-      assert stats.mode == 55
-    end
-
-    @standard_deviation_sample [600, 470, 170, 430, 300]
-    test "statistical standard deviation is calculated correctly" do
-      scenarios = [
-        %Scenario{
-          run_time_data: %CollectionData{samples: @standard_deviation_sample},
-          memory_usage_data: %CollectionData{samples: @standard_deviation_sample}
-        }
-      ]
-
-      suite = Statistics.statistics(%Suite{scenarios: scenarios})
-
-      [%Scenario{run_time_data: %CollectionData{statistics: stats}}] = suite.scenarios
-      assert_in_delta stats.std_dev, 164.7, 0.1
-      assert_in_delta stats.std_dev_ratio, 0.41, 0.01
-    end
-
     test "preserves all other keys in the suite handed to it" do
       suite = %Suite{
         scenarios: [],
@@ -184,32 +153,6 @@ defmodule Benchee.StatistcsTest do
           }
         ]
       } = Statistics.statistics(suite)
-    end
-
-    @all_zeros [0, 0, 0, 0, 0]
-    test "doesn't blow up when all measurements are zeros (mostly memory measurement)" do
-      scenarios = [
-        %Scenario{
-          run_time_data: %CollectionData{samples: @all_zeros}
-        },
-        %Scenario{
-          run_time_data: %CollectionData{samples: @all_zeros}
-        }
-      ]
-
-      suite = Statistics.statistics(%Suite{scenarios: scenarios})
-
-      [
-        %Scenario{
-          run_time_data: %CollectionData{statistics: run_time_stats_1}
-        },
-        %Scenario{
-          run_time_data: %CollectionData{statistics: run_time_stats_2}
-        }
-      ] = suite.scenarios
-
-      assert run_time_stats_1.average == 0.0
-      assert run_time_stats_2.sample_size == 5
     end
 
     @nothing []

--- a/test/statistex/mode_test.exs
+++ b/test/statistex/mode_test.exs
@@ -1,0 +1,4 @@
+defmodule Statistex.ModeTest do
+  use ExUnit.Case, async: true
+  doctest Statistex.Mode
+end

--- a/test/statistex/percentile_test.exs
+++ b/test/statistex/percentile_test.exs
@@ -1,6 +1,6 @@
-defmodule Benchee.Statistics.PercentileTest do
+defmodule Statistex.PercentileTest do
   use ExUnit.Case, async: true
-  alias Benchee.Statistics.Percentile
+  alias Statistex.Percentile
   doctest Percentile
 
   @nist_sample_data [

--- a/test/statistex/percentile_test.exs
+++ b/test/statistex/percentile_test.exs
@@ -27,7 +27,7 @@ defmodule Statistex.PercentileTest do
   end
 
   test "an empty list raises an argument error" do
-    assert percentiles([], [1]) == {:error, :empty_list}
+    assert_raise ArgumentError, fn -> percentiles([], [1]) end
   end
 
   describe "a list of one element" do

--- a/test/statistex/percentile_test.exs
+++ b/test/statistex/percentile_test.exs
@@ -1,7 +1,8 @@
 defmodule Statistex.PercentileTest do
   use ExUnit.Case, async: true
-  alias Statistex.Percentile
-  doctest Percentile
+  import Statistex.Percentile
+
+  doctest Statistex.Percentile
 
   @nist_sample_data [
     95.1772,
@@ -21,12 +22,12 @@ defmodule Statistex.PercentileTest do
   # Test data from:
   #   http://www.itl.nist.gov/div898/handbook/prc/section2/prc262.htm
   test "90th percentile" do
-    %{90 => result} = Percentile.percentiles(@nist_sample_data, 90)
+    %{90 => result} = percentiles(@nist_sample_data, 90)
     assert Float.round(result, 4) == 95.1981
   end
 
   test "an empty list raises an argument error" do
-    assert_raise ArgumentError, fn -> Percentile.percentiles([], [1]) end
+    assert percentiles([], [1]) == {:error, :empty_list}
   end
 
   describe "a list of one element" do
@@ -35,17 +36,17 @@ defmodule Statistex.PercentileTest do
     end
 
     test "1st percentile", %{samples: samples} do
-      %{1 => result} = Percentile.percentiles(samples, [1])
+      %{1 => result} = percentiles(samples, [1])
       assert result == 300.0
     end
 
     test "50th percentile", %{samples: samples} do
-      %{50 => result} = Percentile.percentiles(samples, [50])
+      %{50 => result} = percentiles(samples, [50])
       assert result == 300.0
     end
 
     test "99th percentile", %{samples: samples} do
-      %{99 => result} = Percentile.percentiles(samples, [99])
+      %{99 => result} = percentiles(samples, [99])
       assert result == 300.0
     end
   end
@@ -56,17 +57,17 @@ defmodule Statistex.PercentileTest do
     end
 
     test "1st percentile", %{samples: samples} do
-      %{1 => result} = Percentile.percentiles(samples, [1])
+      %{1 => result} = percentiles(samples, [1])
       assert result == 203.0
     end
 
     test "50th percentile", %{samples: samples} do
-      %{50 => result} = Percentile.percentiles(samples, [50])
+      %{50 => result} = percentiles(samples, [50])
       assert result == 250.0
     end
 
     test "99th percentile", %{samples: samples} do
-      %{99 => result} = Percentile.percentiles(samples, [99])
+      %{99 => result} = percentiles(samples, [99])
       assert result == 300.0
     end
   end
@@ -77,17 +78,17 @@ defmodule Statistex.PercentileTest do
     end
 
     test "1st percentile", %{samples: samples} do
-      %{1 => result} = Percentile.percentiles(samples, [1])
+      %{1 => result} = percentiles(samples, [1])
       assert result == 104.0
     end
 
     test "50th percentile", %{samples: samples} do
-      %{50 => result} = Percentile.percentiles(samples, [50])
+      %{50 => result} = percentiles(samples, [50])
       assert result == 200.0
     end
 
     test "99th percentile", %{samples: samples} do
-      %{99 => result} = Percentile.percentiles(samples, [99])
+      %{99 => result} = percentiles(samples, [99])
       assert result == 300.0
     end
   end

--- a/test/statistex_test.exs
+++ b/test/statistex_test.exs
@@ -1,0 +1,4 @@
+defmodule Statistex.StatistexTest do
+  use ExUnit.Case, async: true
+  doctest Statistex
+end


### PR DESCRIPTION
This is step one where Statistex still lives in benchee. Goal is to have it in `lib` so that it could just be copy and pasted over into its own repository.