### PR TITLE
Add reduction counting

### DIFF
--- a/lib/benchee/benchmark/collect/reductions.ex
+++ b/lib/benchee/benchmark/collect/reductions.ex
@@ -1,0 +1,42 @@
+defmodule Benchee.Benchmark.Collect.Reductions do
+  @moduledoc false
+
+  @behaviour Benchee.Benchmark.Collect
+
+  def collect(fun) do
+    parent = self()
+
+    # The reduction offset here is important - this is the number of reductions
+    # that are needed for the other functions in our runner process that don't
+    # have anything to do with the function that's being benchmarked.
+    #
+    # It includes the one reduction for the function that we have wrapping the
+    # actual function being benchmarked, and then the rest are for the
+    # collection of the initial reduction count and the ending reduction count.
+    # These numbers vary based on the Erlang/OTP version, but not based on the
+    # Elixir version (based on my experiements of everything from OTP 19 - 22
+    # and Elixir 1.6 - 1.8).
+    reduction_offset =
+      case Benchee.System.erlang() do
+        "22" <> _ -> 8
+        "21" <> _ -> 8
+        "20" <> _ -> 7
+        "19" <> _ -> 7
+      end
+
+    spawn_link(fn ->
+      start = get_reductions()
+      output = fun.()
+      send(parent, {get_reductions() - start - reduction_offset, output})
+    end)
+
+    receive do
+      result -> result
+    end
+  end
+
+  defp get_reductions do
+    {:reductions, reductions} = Process.info(self(), :reductions)
+    reductions
+  end
+end

--- a/lib/benchee/benchmark/collect/reductions.ex
+++ b/lib/benchee/benchmark/collect/reductions.ex
@@ -6,28 +6,10 @@ defmodule Benchee.Benchmark.Collect.Reductions do
   def collect(fun) do
     parent = self()
 
-    # The reduction offset here is important - this is the number of reductions
-    # that are needed for the other functions in our runner process that don't
-    # have anything to do with the function that's being benchmarked.
-    #
-    # It includes the one reduction for the function that we have wrapping the
-    # actual function being benchmarked, and then the rest are for the
-    # collection of the initial reduction count and the ending reduction count.
-    # These numbers vary based on the Erlang/OTP version, but not based on the
-    # Elixir version (based on my experiements of everything from OTP 19 - 22
-    # and Elixir 1.6 - 1.8).
-    reduction_offset =
-      case Benchee.System.erlang() do
-        "22" <> _ -> 8
-        "21" <> _ -> 8
-        "20" <> _ -> 7
-        "19" <> _ -> 7
-      end
-
     spawn_link(fn ->
       start = get_reductions()
       output = fun.()
-      send(parent, {get_reductions() - start - reduction_offset, output})
+      send(parent, {get_reductions() - start, output})
     end)
 
     receive do

--- a/lib/benchee/benchmark/collect/reductions.ex
+++ b/lib/benchee/benchmark/collect/reductions.ex
@@ -9,11 +9,11 @@ defmodule Benchee.Benchmark.Collect.Reductions do
     spawn_link(fn ->
       start = get_reductions()
       output = fun.()
-      send(parent, {get_reductions() - start, output})
+      send(parent, {:reductions, get_reductions() - start, output})
     end)
 
     receive do
-      result -> result
+      {:reductions, reductions, output} -> {reductions, output}
     end
   end
 

--- a/lib/benchee/benchmark/runner.ex
+++ b/lib/benchee/benchmark/runner.ex
@@ -67,8 +67,7 @@ defmodule Benchee.Benchmark.Runner do
   end
 
   defp measure_scenario_parallel(config, scenario, scenario_context) do
-    1..config.parallel
-    |> Parallel.map(fn _ -> measure_scenario(scenario, scenario_context) end)
+    Parallel.map(1..config.parallel, fn _ -> measure_scenario(scenario, scenario_context) end)
   end
 
   defp add_measurements_to_scenario(measurements, scenario) do
@@ -96,7 +95,12 @@ defmodule Benchee.Benchmark.Runner do
       |> deduct_function_call_overhead(scenario_context.function_call_overhead)
 
     memory_usages = run_memory_benchmark(scenario, scenario_context)
-    reductions = run_reductions_benchmark(scenario, scenario_context)
+
+    reductions =
+      scenario
+      |> run_reductions_benchmark(scenario_context)
+      |> deduct_reduction_overhead()
+
     Hooks.run_after_scenario(scenario, scenario_context)
 
     {run_times, memory_usages, reductions}
@@ -131,6 +135,25 @@ defmodule Benchee.Benchmark.Runner do
     Enum.map(run_times, fn time ->
       max(time - overhead, 0)
     end)
+  end
+
+  defp deduct_reduction_overhead([]), do: []
+
+  defp deduct_reduction_overhead(reductions) do
+    me = self()
+    ref = make_ref()
+
+    spawn(fn ->
+      {offset, _} = Collect.Reductions.collect(fn -> nil end)
+      send(me, {ref, offset})
+    end)
+
+    offset =
+      receive do
+        {^ref, offset} -> offset
+      end
+
+    Enum.map(reductions, &(&1 - offset))
   end
 
   defp run_reductions_benchmark(_, %ScenarioContext{config: %{reduction_time: 0.0}}) do
@@ -216,7 +239,7 @@ defmodule Benchee.Benchmark.Runner do
          _collector,
          measurements
        )
-       when current_time > end_time do
+       when current_time > end_time and measurements != [] do
     # restore correct order - important for graphing
     Enum.reverse(measurements)
   end

--- a/lib/benchee/collection_data.ex
+++ b/lib/benchee/collection_data.ex
@@ -5,7 +5,9 @@ defmodule Benchee.CollectionData do
   Consists of the recorded `samples` and the statistics computed from them.
   """
 
-  defstruct [:statistics, samples: []]
+  alias Benchee.Statistics
+
+  defstruct statistics: %Statistics{}, samples: []
 
   @typedoc """
   Samples and statistics.
@@ -14,6 +16,6 @@ defmodule Benchee.CollectionData do
   """
   @type t :: %__MODULE__{
           samples: [float | non_neg_integer],
-          statistics: Benchee.Statistics.t() | nil
+          statistics: Statistics.t()
         }
 end

--- a/lib/benchee/configuration.ex
+++ b/lib/benchee/configuration.ex
@@ -17,6 +17,7 @@ defmodule Benchee.Configuration do
             time: 5,
             warmup: 2,
             memory_time: 0.0,
+            reduction_time: 0.0,
             pre_check: false,
             formatters: [Console],
             percentiles: [50, 99],
@@ -135,6 +136,7 @@ defmodule Benchee.Configuration do
           time: number,
           warmup: number,
           memory_time: number,
+          reduction_time: number,
           pre_check: boolean,
           formatters: [(Suite.t() -> Suite.t()) | module | {module, map}],
           print: map,
@@ -151,7 +153,7 @@ defmodule Benchee.Configuration do
           title: String.t() | nil
         }
 
-  @time_keys [:time, :warmup, :memory_time]
+  @time_keys [:time, :warmup, :memory_time, :reduction_time]
 
   @doc """
   Returns the initial benchmark configuration for Benchee, composed of defaults

--- a/lib/benchee/conversion.ex
+++ b/lib/benchee/conversion.ex
@@ -5,7 +5,6 @@ defmodule Benchee.Conversion do
   Can be used by plugins to use benchee unit scaling logic.
   """
 
-  alias Benchee.Scenario
   alias Benchee.Conversion.{Count, Duration, Memory}
 
   @doc """
@@ -53,38 +52,23 @@ defmodule Benchee.Conversion do
       }
   """
   def units(scenarios, scaling_strategy) do
-    run_time_measurements =
-      scenarios
-      |> Enum.flat_map(fn scenario -> Map.to_list(scenario.run_time_data.statistics) end)
-      |> Enum.group_by(fn {stat_name, _} -> stat_name end, fn {_, value} -> value end)
-
-    reductions_measurements =
-      scenarios
-      |> Enum.flat_map(fn scenario -> Map.to_list(scenario.reductions_data.statistics) end)
-      |> Enum.group_by(fn {stat_name, _} -> stat_name end, fn {_, value} -> value end)
-
-    memory_measurements =
-      scenarios
-      |> Enum.flat_map(fn
-        %Scenario{memory_usage_data: %{statistics: nil}} ->
-          []
-
-        %Scenario{memory_usage_data: %{statistics: memory_usage_statistics}} ->
-          Map.to_list(memory_usage_statistics)
-      end)
-      |> Enum.group_by(fn {stat_name, _} -> stat_name end, fn {_, value} -> value end)
-
-    memory_average =
-      case memory_measurements do
-        map when map_size(map) == 0 -> []
-        _ -> memory_measurements.average
-      end
+    run_time_measurements = measurments_for(scenarios, :run_time_data)
+    reductions_measurements = measurments_for(scenarios, :reductions_data)
+    memory_measurements = measurments_for(scenarios, :memory_usage_data)
 
     %{
       run_time: Duration.best(run_time_measurements.average, strategy: scaling_strategy),
       ips: Count.best(run_time_measurements.ips, strategy: scaling_strategy),
-      memory: Memory.best(memory_average, strategy: scaling_strategy),
+      memory: Memory.best(memory_measurements.average, strategy: scaling_strategy),
       reduction_count: Count.best(reductions_measurements.average, strategry: scaling_strategy)
     }
+  end
+
+  defp measurments_for(scenarios, path) do
+    paths = [Access.key(path), Access.key(:statistics)]
+
+    scenarios
+    |> Enum.flat_map(fn scenario -> scenario |> get_in(paths) |> Map.to_list() end)
+    |> Enum.group_by(fn {stat_name, _} -> stat_name end, fn {_, value} -> value end)
   end
 end

--- a/lib/benchee/conversion/scale.ex
+++ b/lib/benchee/conversion/scale.ex
@@ -81,6 +81,8 @@ defmodule Benchee.Conversion.Scale do
       iex> Benchee.Conversion.Scale.scale 12345, unit
       12.345
   """
+  def scale(nil, _), do: 0.0
+
   def scale(value, %Unit{magnitude: magnitude}) do
     value / magnitude
   end

--- a/lib/benchee/conversion/scale.ex
+++ b/lib/benchee/conversion/scale.ex
@@ -81,8 +81,6 @@ defmodule Benchee.Conversion.Scale do
       iex> Benchee.Conversion.Scale.scale 12345, unit
       12.345
   """
-  def scale(nil, _), do: 0.0
-
   def scale(value, %Unit{magnitude: magnitude}) do
     value / magnitude
   end

--- a/lib/benchee/formatters/console.ex
+++ b/lib/benchee/formatters/console.ex
@@ -19,12 +19,22 @@ defmodule Benchee.Formatters.Console do
       map.flatten       781.25 KB - 1.25x memory usage
 
       **All measurements for memory usage were the same**
+
+      Reduction count statistics:
+
+      Name              average  deviation      median      99th %
+      flat_map           417.00      ±9.40      411.45      715.21
+      map.flatten        806.89     ±16.62      768.02     1170.67
+
+      Comparison:
+      flat_map           417.00
+      map.flatten        806.89 - 1.93x more reductions
   """
 
   @behaviour Benchee.Formatter
 
   alias Benchee.Suite
-  alias Benchee.Formatters.Console.{Memory, RunTime}
+  alias Benchee.Formatters.Console.{Memory, Reductions, RunTime}
 
   @doc """
   Formats the benchmark statistics to a report suitable for output on the CLI.
@@ -121,7 +131,9 @@ defmodule Benchee.Formatters.Console do
   defp generate_output(scenarios, config, input) do
     [
       suite_header(input, config)
-      | RunTime.format_scenarios(scenarios, config) ++ Memory.format_scenarios(scenarios, config)
+      | RunTime.format_scenarios(scenarios, config) ++
+          Memory.format_scenarios(scenarios, config) ++
+          Reductions.format_scenarios(scenarios, config)
     ]
   end
 

--- a/lib/benchee/formatters/console/reductions.ex
+++ b/lib/benchee/formatters/console/reductions.ex
@@ -207,12 +207,19 @@ defmodule Benchee.Formatters.Console.Reductions do
   defp reference_report(scenario, %{reduction_count: reductions_unit}, label_width) do
     %Scenario{name: name, reductions_data: %{statistics: %Statistics{median: median}}} = scenario
 
+    count =
+      if is_nil(median) do
+        @na
+      else
+        Helpers.count_output(median, reductions_unit)
+      end
+
     "~*s~*s\n"
     |> :io_lib.format([
       -label_width,
       name,
       @median_width,
-      Helpers.count_output(median, reductions_unit)
+      count
     ])
     |> to_string
   end
@@ -223,7 +230,13 @@ defmodule Benchee.Formatters.Console.Reductions do
       scenarios_to_compare,
       fn scenario ->
         statistics = scenario.reductions_data.statistics
-        reductions_format = Helpers.count_output(statistics.average, units.reduction_count)
+
+        reductions_format =
+          if is_nil(statistics.average) do
+            @na
+          else
+            Helpers.count_output(statistics.average, units.reduction_count)
+          end
 
         Helpers.format_comparison(
           scenario.name,

--- a/lib/benchee/output/benchmark_printer.ex
+++ b/lib/benchee/output/benchmark_printer.ex
@@ -50,10 +50,11 @@ defmodule Benchee.Output.BenchmarkPrinter do
          time: time,
          warmup: warmup,
          inputs: inputs,
-         memory_time: memory_time
+         memory_time: memory_time,
+         reduction_time: reduction_time
        }) do
     scenario_count = length(scenarios)
-    exec_time = warmup + time + memory_time
+    exec_time = warmup + time + memory_time + reduction_time
     total_time = scenario_count * exec_time
 
     IO.puts("""
@@ -61,6 +62,7 @@ defmodule Benchee.Output.BenchmarkPrinter do
     warmup: #{Duration.format(warmup)}
     time: #{Duration.format(time)}
     memory time: #{Duration.format(memory_time)}
+    reduction time: #{Duration.format(reduction_time)}
     parallel: #{parallel}
     inputs: #{inputs_out(inputs)}
     Estimated total run time: #{Duration.format(total_time)}
@@ -79,7 +81,9 @@ defmodule Benchee.Output.BenchmarkPrinter do
   Prints a notice which job is currently being benchmarked.
   """
   def benchmarking(_, _, %{print: %{benchmarking: false}}), do: nil
-  def benchmarking(_, _, %{time: 0.0, warmup: 0.0, memory_time: 0.0}), do: nil
+
+  def benchmarking(_, _, %{time: 0.0, warmup: 0.0, memory_time: 0.0, reduction_time: 0.0}),
+    do: nil
 
   def benchmarking(name, input_name, _config) do
     IO.puts("Benchmarking #{name}#{input_information(input_name)}...")

--- a/lib/benchee/relative_statistics.ex
+++ b/lib/benchee/relative_statistics.ex
@@ -45,7 +45,8 @@ defmodule Benchee.RelativeStatistics do
   @spec sort([Scenario.t()]) :: [Scenario.t()]
   defp sort(scenarios) do
     Enum.sort_by(scenarios, fn scenario ->
-      {scenario.run_time_data.statistics.average, scenario.memory_usage_data.statistics.average}
+      {scenario.run_time_data.statistics.average, scenario.memory_usage_data.statistics.average,
+       scenario.reductions_data.statistics.average}
     end)
   end
 
@@ -74,6 +75,9 @@ defmodule Benchee.RelativeStatistics do
       end)
       |> update_in([Access.key!(:memory_usage_data), Access.key!(:statistics)], fn statistics ->
         add_relative_statistics(statistics, reference.memory_usage_data.statistics)
+      end)
+      |> update_in([Access.key!(:reductions_data), Access.key!(:statistics)], fn statistics ->
+        add_relative_statistics(statistics, reference.reductions_data.statistics)
       end)
     end)
   end

--- a/lib/benchee/scenario.ex
+++ b/lib/benchee/scenario.ex
@@ -31,7 +31,8 @@ defmodule Benchee.Scenario do
     :after_scenario,
     :tag,
     run_time_data: %CollectionData{},
-    memory_usage_data: %CollectionData{}
+    memory_usage_data: %CollectionData{},
+    reductions_data: %CollectionData{}
   ]
 
   @typedoc """
@@ -56,6 +57,7 @@ defmodule Benchee.Scenario do
           input: any | nil,
           run_time_data: CollectionData.t(),
           memory_usage_data: CollectionData.t(),
+          reductions_data: CollectionData.t(),
           before_each: Hooks.hook_function() | nil,
           after_each: Hooks.hook_function() | nil,
           before_scenario: Hooks.hook_function() | nil,

--- a/lib/benchee/statistics.ex
+++ b/lib/benchee/statistics.ex
@@ -178,6 +178,7 @@ defmodule Benchee.Statistics do
       |> add_ips
 
     memory_stats = calculate_statistics(scenario.memory_usage_data.samples, percentiles)
+    reductions_stats = calculate_statistics(scenario.reductions_data.samples, percentiles)
 
     %Scenario{
       scenario
@@ -188,6 +189,10 @@ defmodule Benchee.Statistics do
         memory_usage_data: %CollectionData{
           scenario.memory_usage_data
           | statistics: memory_stats
+        },
+        reductions_data: %CollectionData{
+          scenario.reductions_data
+          | statistics: reductions_stats
         }
     }
   end

--- a/lib/benchee/system.ex
+++ b/lib/benchee/system.ex
@@ -29,9 +29,9 @@ defmodule Benchee.System do
     %Suite{suite | system: system_info}
   end
 
-  defp elixir, do: System.version()
-
-  defp erlang do
+  @doc false
+  @spec erlang() :: String.t()
+  def erlang do
     otp_release = :erlang.system_info(:otp_release)
     file = Path.join([:code.root_dir(), "releases", otp_release, "OTP_VERSION"])
 
@@ -43,6 +43,8 @@ defmodule Benchee.System do
         IO.puts("Error trying to dermine erlang version #{reason}")
     end
   end
+
+  defp elixir, do: System.version()
 
   defp num_cores do
     System.schedulers_online()

--- a/lib/benchee/system.ex
+++ b/lib/benchee/system.ex
@@ -29,9 +29,7 @@ defmodule Benchee.System do
     %Suite{suite | system: system_info}
   end
 
-  @doc false
-  @spec erlang() :: String.t()
-  def erlang do
+  defp erlang do
     otp_release = :erlang.system_info(:otp_release)
     file = Path.join([:code.root_dir(), "releases", otp_release, "OTP_VERSION"])
 

--- a/samples/measure_reductions.exs
+++ b/samples/measure_reductions.exs
@@ -1,0 +1,29 @@
+map_fun = fn i -> [i, i * i] end
+
+Benchee.run(
+  %{
+    "flat_map" => fn input ->
+      if rem(Enum.random(1..5), 2) == 0 do
+        _ = Enum.random(1..10) + Enum.random(1..10)
+        Enum.flat_map(input, map_fun)
+      else
+        Enum.flat_map(input, map_fun)
+      end
+    end,
+    "map.flatten" => fn input ->
+      if rem(Enum.random(1..5), 2) == 0 do
+        _ = Enum.random(1..10) + Enum.random(1..10)
+        input |> Enum.map(map_fun) |> List.flatten()
+      else
+        input |> Enum.map(map_fun) |> List.flatten()
+      end
+    end
+  },
+  inputs: %{
+    "Small" => Enum.to_list(1..10),
+    "Bigger" => Enum.to_list(1..100)
+  },
+  time: 0.1,
+  warmup: 0.1,
+  reduction_time: 0.1
+)

--- a/samples/measure_reductions.exs
+++ b/samples/measure_reductions.exs
@@ -3,6 +3,9 @@ map_fun = fn i -> [i, i * i] end
 Benchee.run(
   %{
     "flat_map" => fn input ->
+      # We need randomness here so we have differing reduction sizes. Otherwise,
+      # we only get the output when all measurements are the same, which isn't
+      # very helpful for testing.
       if rem(Enum.random(1..5), 2) == 0 do
         _ = Enum.random(1..10) + Enum.random(1..10)
         Enum.flat_map(input, map_fun)

--- a/test/benchee/benchmark/collect/reductions_test.exs
+++ b/test/benchee/benchmark/collect/reductions_test.exs
@@ -1,0 +1,17 @@
+defmodule Benchee.Collect.ReductionsTest do
+  use ExUnit.Case, async: true
+  alias Benchee.Benchmark.Collect.Reductions
+
+  describe "collect/1" do
+    test "returns the reduction count and result of the function" do
+      assert {32, [1, 2, 3, 4, 5, 6, 7, 8, 9]} =
+               Reductions.collect(fn -> Enum.to_list(1..9) end)
+
+      assert {35, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]} =
+               Reductions.collect(fn -> Enum.to_list(1..10) end)
+
+      assert {38, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]} =
+               Reductions.collect(fn -> Enum.to_list(1..11) end)
+    end
+  end
+end

--- a/test/benchee/benchmark/collect/reductions_test.exs
+++ b/test/benchee/benchmark/collect/reductions_test.exs
@@ -4,14 +4,23 @@ defmodule Benchee.Collect.ReductionsTest do
 
   describe "collect/1" do
     test "returns the reduction count and result of the function" do
-      assert {32, [1, 2, 3, 4, 5, 6, 7, 8, 9]} =
+      assert {reductions, [1, 2, 3, 4, 5, 6, 7, 8, 9]} =
                Reductions.collect(fn -> Enum.to_list(1..9) end)
 
-      assert {35, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]} =
+      assert reductions >= 24
+      assert reductions <= 48
+
+      assert {reductions, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]} =
                Reductions.collect(fn -> Enum.to_list(1..10) end)
 
-      assert {38, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]} =
+      assert reductions >= 26
+      assert reductions <= 51
+
+      assert {reductions, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]} =
                Reductions.collect(fn -> Enum.to_list(1..11) end)
+
+      assert reductions >= 28
+      assert reductions <= 54
     end
   end
 end

--- a/test/benchee/benchmark/collect/reductions_test.exs
+++ b/test/benchee/benchmark/collect/reductions_test.exs
@@ -8,19 +8,19 @@ defmodule Benchee.Collect.ReductionsTest do
                Reductions.collect(fn -> Enum.to_list(1..9) end)
 
       assert reductions >= 24
-      assert reductions <= 48
+      assert reductions <= 56
 
       assert {reductions, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]} =
                Reductions.collect(fn -> Enum.to_list(1..10) end)
 
       assert reductions >= 26
-      assert reductions <= 51
+      assert reductions <= 59
 
       assert {reductions, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]} =
                Reductions.collect(fn -> Enum.to_list(1..11) end)
 
       assert reductions >= 28
-      assert reductions <= 54
+      assert reductions <= 62
     end
   end
 end

--- a/test/benchee/benchmark/runner_test.exs
+++ b/test/benchee/benchmark/runner_test.exs
@@ -121,6 +121,25 @@ defmodule Benchee.Benchmark.RunnerTest do
       assert length(memory_usages) > 0
     end
 
+    test "measures the reduction count of a scenario" do
+      suite =
+        test_suite(%Suite{
+          configuration: %{time: 60_000, warmup: 10_000, reduction_time: 2_000_000}
+        })
+
+      new_suite =
+        suite
+        |> Benchmark.benchmark("Name", fn ->
+          Enum.map(0..100, fn _ -> [12.23, 30.536, 30.632, 7398.3295] end)
+        end)
+        |> Benchmark.collect(TestPrinter)
+
+      reduction_counts = hd(new_suite.scenarios).reductions_data.samples
+
+      assert length(reduction_counts) > 0
+      assert Enum.all?(reduction_counts, fn count -> count >= 347 and count <= 567 end)
+    end
+
     @tag :memory_measure
     test "records memory when the function only runs once" do
       suite = test_suite(%Suite{configuration: %{time: 0.0, warmup: 0.0, memory_time: 1_000_000}})

--- a/test/benchee/benchmark/runner_test.exs
+++ b/test/benchee/benchmark/runner_test.exs
@@ -124,7 +124,7 @@ defmodule Benchee.Benchmark.RunnerTest do
     test "measures the reduction count of a scenario" do
       suite =
         test_suite(%Suite{
-          configuration: %{time: 60_000, warmup: 10_000, reduction_time: 2_000_000}
+          configuration: %{time: 1, warmup: 1, reduction_time: 1}
         })
 
       new_suite =
@@ -137,7 +137,7 @@ defmodule Benchee.Benchmark.RunnerTest do
       reduction_counts = hd(new_suite.scenarios).reductions_data.samples
 
       assert length(reduction_counts) > 0
-      assert Enum.all?(reduction_counts, fn count -> count >= 347 and count <= 567 end)
+      assert Enum.all?(reduction_counts, fn count -> count >= 344 and count <= 567 end)
     end
 
     @tag :memory_measure

--- a/test/benchee/formatters/console/reductions_test.exs
+++ b/test/benchee/formatters/console/reductions_test.exs
@@ -1,0 +1,516 @@
+defmodule Benchee.Formatters.Console.ReductionsTest do
+  use ExUnit.Case, async: true
+  doctest Benchee.Formatters.Console.Reductions
+
+  alias Benchee.{CollectionData, Formatters.Console.Reductions, Scenario, Statistics}
+
+  @console_config %{
+    comparison: true,
+    unit_scaling: :best,
+    extended_statistics: false
+  }
+
+  describe ".format_scenarios" do
+    test "adjusts the label width to longest name" do
+      scenarios = [
+        %Scenario{
+          name: "First",
+          reductions_data: %CollectionData{
+            statistics: %Statistics{
+              average: 200.0,
+              ips: 5_000.0,
+              std_dev_ratio: 0.1,
+              median: 195.5,
+              percentiles: %{99 => 300.1},
+              sample_size: 10
+            }
+          },
+          run_time_data: %CollectionData{statistics: %Statistics{average: 100.0, ips: 1_000.0}}
+        },
+        %Scenario{
+          name: "Second",
+          reductions_data: %CollectionData{
+            statistics: %Statistics{
+              average: 400.0,
+              ips: 2_500.0,
+              std_dev_ratio: 0.1,
+              median: 375.0,
+              percentiles: %{99 => 400.1},
+              sample_size: 10,
+              relative_more: 2.0,
+              absolute_difference: 200.0
+            }
+          },
+          run_time_data: %CollectionData{statistics: %Statistics{average: 100.0, ips: 1_000.0}}
+        }
+      ]
+
+      expected_width = String.length("Second")
+
+      [_reductions_header, header, result_1, result_2 | _dont_care] =
+        Reductions.format_scenarios(scenarios, @console_config)
+
+      assert_column_width("Name", header, expected_width)
+      assert_column_width("First", result_1, expected_width)
+      assert_column_width("Second", result_2, expected_width)
+
+      third_length = 40
+      third_name = String.duplicate("a", third_length)
+
+      long_scenario = %Scenario{
+        name: third_name,
+        reductions_data: %CollectionData{
+          statistics: %Statistics{
+            average: 400.1,
+            ips: 2_500.0,
+            std_dev_ratio: 0.1,
+            median: 375.0,
+            percentiles: %{99 => 500.1},
+            sample_size: 10,
+            relative_more: 2.005,
+            absolute_difference: 200.1
+          }
+        },
+        run_time_data: %CollectionData{statistics: %Statistics{average: 100.0, ips: 1_000.0}}
+      }
+
+      longer_scenarios = scenarios ++ [long_scenario]
+
+      # Include extra long name, expect width of 40 characters
+      [_reductions_header, header, result_1, result_2, result_3 | _dont_care] =
+        Reductions.format_scenarios(longer_scenarios, @console_config)
+
+      assert_column_width("Name", header, third_length)
+      assert_column_width("First", result_1, third_length)
+      assert_column_width("Second", result_2, third_length)
+      assert_column_width(third_name, result_3, third_length)
+    end
+
+    test "can omit the comparisons" do
+      scenarios = [
+        %Scenario{
+          name: "Second",
+          reductions_data: %CollectionData{
+            statistics: %Statistics{
+              average: 200.0,
+              ips: 5_000.0,
+              std_dev_ratio: 0.1,
+              median: 195.5,
+              percentiles: %{99 => 300.1},
+              sample_size: 10
+            }
+          },
+          run_time_data: %CollectionData{statistics: %Statistics{average: 100.0, ips: 1_000.0}}
+        },
+        %Scenario{
+          name: "First",
+          reductions_data: %CollectionData{
+            statistics: %Statistics{
+              average: 100.0,
+              ips: 10_000.0,
+              std_dev_ratio: 0.1,
+              median: 90.0,
+              percentiles: %{99 => 200.1},
+              sample_size: 10
+            }
+          },
+          run_time_data: %CollectionData{statistics: %Statistics{average: 100.0, ips: 1_000.0}}
+        }
+      ]
+
+      output =
+        Enum.join(
+          Reductions.format_scenarios(scenarios, %{
+            comparison: false,
+            unit_scaling: :best,
+            extended_statistics: false
+          })
+        )
+
+      refute output =~ ~r/Comparison/i
+      refute output =~ ~r/^First\s+90$/m
+    end
+
+    test "creates comparisons" do
+      scenarios = [
+        %Scenario{
+          name: "First",
+          reductions_data: %CollectionData{
+            statistics: %Statistics{
+              average: 90.0,
+              ips: 10_000.0,
+              std_dev_ratio: 0.1,
+              median: 90.0,
+              percentiles: %{99 => 500.1},
+              sample_size: 10
+            }
+          },
+          run_time_data: %CollectionData{statistics: %Statistics{average: 100.0, ips: 1_000.0}}
+        },
+        %Scenario{
+          name: "Second",
+          reductions_data: %CollectionData{
+            statistics: %Statistics{
+              average: 195.5,
+              ips: 5_000.0,
+              std_dev_ratio: 0.1,
+              median: 195.5,
+              percentiles: %{99 => 500.1},
+              sample_size: 10,
+              relative_more: 2.17,
+              absolute_difference: 105.5
+            }
+          },
+          run_time_data: %CollectionData{statistics: %Statistics{average: 100.0, ips: 1_000.0}}
+        }
+      ]
+
+      output = Reductions.format_scenarios(scenarios, @console_config)
+      [_, _, _, _, comp_header, reference, slower] = output
+
+      assert comp_header =~ ~r/Comparison/
+      assert reference =~ ~r/^First\s+90$/m
+      assert slower =~ ~r/^Second\s+195.50\s+- 2.17x reduction count \+105\.50$/m
+    end
+
+    test "adjusts the label width to longest name for comparisons" do
+      second_name = String.duplicate("a", 40)
+
+      scenarios = [
+        %Scenario{
+          name: "First",
+          reductions_data: %CollectionData{
+            statistics: %Statistics{
+              average: 100.0,
+              ips: 10_000.0,
+              std_dev_ratio: 0.1,
+              median: 90.0,
+              percentiles: %{99 => 200.1},
+              sample_size: 10
+            }
+          },
+          run_time_data: %CollectionData{statistics: %Statistics{average: 100.0, ips: 1_000.0}}
+        },
+        %Scenario{
+          name: second_name,
+          reductions_data: %CollectionData{
+            statistics: %Statistics{
+              average: 200.0,
+              ips: 5_000.0,
+              std_dev_ratio: 0.1,
+              median: 195.5,
+              percentiles: %{99 => 300.1},
+              sample_size: 10,
+              relative_more: 2.0,
+              absolute_difference: 100.0
+            }
+          },
+          run_time_data: %CollectionData{statistics: %Statistics{average: 100.0, ips: 1_000.0}}
+        }
+      ]
+
+      expected_width = String.length(second_name)
+
+      [_, _, _, _, _comp_header, reference, slower] =
+        Reductions.format_scenarios(scenarios, @console_config)
+
+      assert_column_width("First", reference, expected_width)
+      assert_column_width(second_name, slower, expected_width)
+    end
+
+    test "doesn't display statistics if all deviations are 0.0" do
+      scenarios = [
+        %Scenario{
+          name: "First",
+          reductions_data: %CollectionData{
+            statistics: %Statistics{
+              average: 100.0,
+              std_dev: 0.0,
+              std_dev_ratio: 0.0,
+              median: 100.0,
+              percentiles: %{99 => 100.0},
+              sample_size: 10
+            }
+          },
+          run_time_data: %CollectionData{statistics: %Statistics{average: 100.0, ips: 1_000.0}}
+        },
+        %Scenario{
+          name: "Second",
+          reductions_data: %CollectionData{
+            statistics: %Statistics{
+              average: 200.0,
+              std_dev: 0.0,
+              std_dev_ratio: 0.0,
+              median: 200.0,
+              percentiles: %{99 => 200.0},
+              sample_size: 10,
+              relative_more: 2.0,
+              absolute_difference: 100.0
+            }
+          },
+          run_time_data: %CollectionData{statistics: %Statistics{average: 100.0, ips: 1_000.0}}
+        }
+      ]
+
+      output =
+        Enum.join(
+          Reductions.format_scenarios(scenarios, %{
+            comparison: true,
+            unit_scaling: :best,
+            extended_statistics: false
+          })
+        )
+
+      refute Regex.match?(~r/Comparison/i, output)
+      refute Regex.match?(~r/average/i, output)
+    end
+
+    test "doesn't create comparisons with only one benchmark run" do
+      scenarios = [
+        %Scenario{
+          name: "First",
+          reductions_data: %CollectionData{
+            statistics: %Statistics{
+              average: 100.0,
+              ips: 10_000.0,
+              std_dev_ratio: 0.1,
+              median: 90.0,
+              percentiles: %{99 => 200.1},
+              sample_size: 10
+            }
+          },
+          run_time_data: %CollectionData{statistics: %Statistics{average: 100.0, ips: 1_000.0}}
+        }
+      ]
+
+      assert [_, header, result] = Reductions.format_scenarios(scenarios, @console_config)
+      refute Regex.match?(~r/(Comparison|x reduction)/, Enum.join([header, result]))
+    end
+
+    test "displays extended statistics" do
+      scenarios = [
+        %Scenario{
+          name: "First job",
+          reductions_data: %CollectionData{
+            statistics: %Statistics{
+              average: 200.0,
+              ips: 5_000.0,
+              std_dev_ratio: 0.1,
+              median: 195.5,
+              percentiles: %{99 => 300.1},
+              minimum: 111.1,
+              maximum: 333.3,
+              mode: 201.2,
+              sample_size: 50_000
+            }
+          },
+          run_time_data: %CollectionData{statistics: %Statistics{average: 100.0, ips: 1_000.0}}
+        }
+      ]
+
+      params = %{
+        comparison: true,
+        unit_scaling: :best,
+        extended_statistics: true
+      }
+
+      output = Reductions.format_scenarios(scenarios, params)
+      [_reductions_title, _header1, _result1, title, header2, result2] = output
+
+      assert title =~ "Extended statistics: "
+      assert header2 =~ "minimum"
+      assert header2 =~ "maximum"
+      assert header2 =~ "sample size"
+      assert header2 =~ "mode"
+      assert result2 =~ "First job"
+      assert result2 =~ "111.10"
+      assert result2 =~ "333.30"
+      assert result2 =~ "50 K"
+      assert result2 =~ "201.20"
+    end
+
+    test "it doesn't blow up if some of the values have no statistics (yes that happened)" do
+      scenarios = [
+        %Scenario{
+          name: "First",
+          reductions_data: %CollectionData{
+            statistics: %Statistics{
+              average: 100.0,
+              std_dev: 0.0,
+              std_dev_ratio: 0.0,
+              median: 100.0,
+              percentiles: %{99 => 100.0},
+              sample_size: 10
+            }
+          },
+          run_time_data: %CollectionData{statistics: %Statistics{}}
+        },
+        %Scenario{
+          name: "Second",
+          reductions_data: %CollectionData{statistics: %Statistics{}},
+          run_time_data: %CollectionData{statistics: %Statistics{}}
+        }
+      ]
+
+      output =
+        Enum.join(
+          Reductions.format_scenarios(scenarios, %{
+            comparison: true,
+            unit_scaling: :best,
+            extended_statistics: false
+          })
+        )
+
+      assert output =~ "First"
+      assert output =~ ~r/Second.+N\/A/i
+      assert output =~ "N/A"
+      assert output =~ "WARNING"
+      assert output =~ "report"
+    end
+
+    test "doesn't display extended statistics if extended_statistics isn't specified" do
+      scenarios = [
+        %Scenario{
+          name: "First job",
+          reductions_data: %CollectionData{
+            statistics: %Statistics{
+              average: 200.0,
+              ips: 5_000.0,
+              std_dev_ratio: 0.1,
+              median: 195.5,
+              percentiles: %{99 => 300.1},
+              minimum: 111.1,
+              maximum: 333.3,
+              mode: 201.2,
+              sample_size: 50_000
+            }
+          },
+          run_time_data: %CollectionData{statistics: %Statistics{average: 100.0, ips: 1_000.0}}
+        }
+      ]
+
+      params = %{
+        unit_scaling: :best
+      }
+
+      output = scenarios |> Reductions.format_scenarios(params) |> Enum.join("")
+
+      refute output =~ "Extended statistics: "
+      refute output =~ "minimum"
+      refute output =~ "maximum"
+      refute output =~ "sample size"
+      refute output =~ "mode"
+      refute output =~ "111.10"
+      refute output =~ "333.30"
+      refute output =~ "50 K"
+      refute output =~ "201.20"
+    end
+
+    test "does nothing when there's no statistics to format" do
+      scenarios = [
+        %Scenario{reductions_data: %CollectionData{statistics: %Statistics{sample_size: 0}}}
+      ]
+
+      assert [] = Reductions.format_scenarios(scenarios, %{})
+    end
+
+    test "it doesn't blow up if some come back with a median of 0.0" do
+      scenarios = [
+        %Scenario{
+          name: "First",
+          reductions_data: %CollectionData{
+            statistics: %Statistics{
+              average: 0.0,
+              median: 0.0,
+              sample_size: 10,
+              percentiles: %{99 => 0.0},
+              std_dev: 0.0,
+              std_dev_ratio: 0.0
+            }
+          },
+          run_time_data: %CollectionData{statistics: %Statistics{}}
+        },
+        %Scenario{
+          name: "Second",
+          reductions_data: %CollectionData{
+            statistics: %Statistics{
+              average: 100.0,
+              median: 100.0,
+              sample_size: 5,
+              percentiles: %{99 => 100.0},
+              std_dev: 5.0,
+              std_dev_ratio: 0.10,
+              relative_more: :infinity,
+              absolute_difference: 100.0
+            }
+          },
+          run_time_data: %CollectionData{statistics: %Statistics{}}
+        }
+      ]
+
+      output =
+        Enum.join(
+          Reductions.format_scenarios(scenarios, %{
+            comparison: true,
+            unit_scaling: :best,
+            extended_statistics: false
+          })
+        )
+
+      assert output =~ "First"
+      assert output =~ "Second"
+      assert output =~ "∞ x reduction count"
+    end
+
+    test "it doesn't blow up if some come back with a median et. al. of nil" do
+      scenarios = [
+        %Scenario{
+          name: "First",
+          reductions_data: %CollectionData{statistics: %Statistics{}},
+          run_time_data: %CollectionData{statistics: %Statistics{}}
+        },
+        %Scenario{
+          name: "Second",
+          reductions_data: %CollectionData{
+            statistics: %Statistics{
+              average: 100.0,
+              median: 100.0,
+              sample_size: 5,
+              percentiles: %{99 => 100.0},
+              std_dev: 5.0,
+              std_dev_ratio: 0.10
+            }
+          },
+          run_time_data: %CollectionData{statistics: %Statistics{}}
+        }
+      ]
+
+      output =
+        Enum.join(
+          Reductions.format_scenarios(scenarios, %{
+            comparison: true,
+            unit_scaling: :best,
+            extended_statistics: false
+          })
+        )
+
+      assert output =~ "First"
+      assert output =~ "Second"
+      refute output =~ "x reduction count"
+    end
+  end
+
+  defp assert_column_width(name, string, expected_width) do
+    expected_width = expected_width + 16
+    n = Regex.escape(name)
+    regex = Regex.compile!("(#{n} +([0-9\.]+( [[:alpha:]]+)?|average))( |$)")
+    [column | _] = Regex.run(regex, string, capture: :all_but_first)
+    column_width = String.length(column)
+
+    assert expected_width == column_width, """
+    Expected column width of #{expected_width}, got #{column_width}
+    line:   #{inspect(String.trim(string))}
+    column: #{inspect(column)}
+    """
+  end
+end

--- a/test/benchee/output/benchmark_printer_test.exs
+++ b/test/benchee/output/benchmark_printer_test.exs
@@ -85,6 +85,7 @@ defmodule Benchee.Output.BenchmarkPrintertest do
               time: 10_000,
               warmup: 0,
               memory_time: 1_000,
+              reduction_time: 0,
               inputs: @inputs
             },
             scenarios: [
@@ -100,6 +101,7 @@ defmodule Benchee.Output.BenchmarkPrintertest do
 
       assert output =~ "time: 10 μs"
       assert output =~ "memory time: 1 μs"
+      assert output =~ "reduction time: 0 ns"
       assert output =~ "parallel: 2"
       assert output =~ "inputs: Arg 1, Arg 2"
       assert output =~ "Estimated total run time: 44 μs"

--- a/test/benchee_test.exs
+++ b/test/benchee_test.exs
@@ -804,6 +804,23 @@ defmodule BencheeTest do
     end
   end
 
+  describe "reduction measurement" do
+    test "measures reduction count when instructed to do so" do
+      output =
+        capture_io(fn ->
+          Benchee.run(
+            %{"To List" => fn -> Enum.to_list(1..100) end},
+            Keyword.merge(
+              @test_configuration,
+              reduction_time: 2
+            )
+          )
+        end)
+
+      assert output =~ ~r/Reduction count statistics:/
+    end
+  end
+
   @slower_regex "\\s+- \\d+\\.\\d+x slower \\+\\d+(\\.\\d+)?.+"
   defp readme_sample_asserts(output, tag_string \\ "") do
     assert output =~ "warmup: 5 ms"

--- a/test/benchee_test.exs
+++ b/test/benchee_test.exs
@@ -812,7 +812,7 @@ defmodule BencheeTest do
             %{"To List" => fn -> Enum.to_list(1..100) end},
             Keyword.merge(
               @test_configuration,
-              reduction_time: 2
+              reduction_time: 0.1
             )
           )
         end)


### PR DESCRIPTION
This has been sitting on my machine like half done for a month or so, and I finally finished it!

This adds reduction counting, which behaves almost exactly like memory measurement. This should finally allow folks to do really high-quality performance testing that won't be affected by all the other random stuff that can affect clock time.

It's still a little rough, but it works!