### PR TITLE
Add support for built-in profilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,8 +230,12 @@ The available options are the following (also documented in [hexdocs](https://he
     * `:none`     - no unit scaling will occur.
 * `:before_scenario`/`after_scenario`/`before_each`/`after_each` - read up on them in the [hooks section](#hooks-setup-teardown-etc)
 * `profile_after` - accepts any of the following options:
-      * a boolean   - `true` will enable profiling with the default profiler (`:cprof`) and `false` will disable profiling. Defaults to `false`.
-      * a profiler  - either as a tuple of `{profiler, opts}` (e.g., `{:fprof, [sort: :own]}`) or just the profiler, which is equivalent to `{profiler, []}`.
+    * a boolean   - `true` will enable profiling with the default profiler (`:eprof`) and `false` will disable profiling. Defaults to `false`.
+    * a profiler  - either as a tuple of `{profiler, opts}` (e.g., `{:fprof, [sort: :own]}`) or just the profiler (e.g., `:fprof`),
+    which is equivalent to `{profiler, []}`. The accepted built-in profilers are
+    [`:cprof`](https://hexdocs.pm/mix/Mix.Tasks.Profile.Cprof.html),
+    [`:eprof`](https://hexdocs.pm/mix/Mix.Tasks.Profile.Eprof.html) and
+    [`:fprof`](https://hexdocs.pm/mix/Mix.Tasks.Profile.Fprof.html).
 
 ### Measuring memory consumption
 

--- a/README.md
+++ b/README.md
@@ -229,6 +229,10 @@ The available options are the following (also documented in [hexdocs](https://he
     * `:smallest` - the smallest best fit unit will be used
     * `:none`     - no unit scaling will occur.
 * `:before_scenario`/`after_scenario`/`before_each`/`after_each` - read up on them in the [hooks section](#hooks-setup-teardown-etc)
+* `profile` - a map of options to enable profiling after each benchmark containing the following keys:
+    * `profiler_after`  - either `true` or `false` to enable/disable the profiler, defaults to `false`.
+    * `profiler`        - one of the built-in profilers to use (either `:cprof`, `:eprof` or `:fprof`), defaults to `:cprof`.
+    * `profiler_opts`   - the option list to pass to the `profile/2` function of the profiler (for more information read the documentation of each profiler).
 
 ### Measuring memory consumption
 

--- a/README.md
+++ b/README.md
@@ -229,10 +229,9 @@ The available options are the following (also documented in [hexdocs](https://he
     * `:smallest` - the smallest best fit unit will be used
     * `:none`     - no unit scaling will occur.
 * `:before_scenario`/`after_scenario`/`before_each`/`after_each` - read up on them in the [hooks section](#hooks-setup-teardown-etc)
-* `profile` - a map of options to enable profiling after each benchmark containing the following keys:
-    * `profiler_after`  - either `true` or `false` to enable/disable the profiler, defaults to `false`.
-    * `profiler`        - one of the built-in profilers to use (either `:cprof`, `:eprof` or `:fprof`), defaults to `:cprof`.
-    * `profiler_opts`   - the option list to pass to the `profile/2` function of the profiler (for more information read the documentation of each profiler).
+* `profile_after` - accepts any of the following options:
+      * a boolean   - `true` will enable profiling with the default profiler (`:cprof`) and `false` will disable profiling. Defaults to `false`.
+      * a profiler  - either as a tuple of `{profiler, opts}` (e.g., `{:fprof, [sort: :own]}`) or just the profiler, which is equivalent to `{profiler, []}`.
 
 ### Measuring memory consumption
 

--- a/lib/benchee.ex
+++ b/lib/benchee.ex
@@ -50,6 +50,7 @@ for {module, moduledoc} <- [{Benchee, elixir_doc}, {:benchee, erlang_doc}] do
       |> Benchee.load()
       |> Benchee.relative_statistics()
       |> Formatter.output()
+      |> Benchee.profile()
     end
 
     defp add_benchmarking_jobs(suite, jobs) do
@@ -70,5 +71,10 @@ for {module, moduledoc} <- [{Benchee, elixir_doc}, {:benchee, erlang_doc}] do
     defdelegate statistics(suite), to: Benchee.Statistics
     defdelegate relative_statistics(suite), to: Benchee.RelativeStatistics
     defdelegate load(suite), to: Benchee.ScenarioLoader
+
+    @doc """
+    See `Benchee.Profile.profile/1`
+    """
+    defdelegate profile(suite), to: Benchee.Profile
   end
 end

--- a/lib/benchee.ex
+++ b/lib/benchee.ex
@@ -71,10 +71,6 @@ for {module, moduledoc} <- [{Benchee, elixir_doc}, {:benchee, erlang_doc}] do
     defdelegate statistics(suite), to: Benchee.Statistics
     defdelegate relative_statistics(suite), to: Benchee.RelativeStatistics
     defdelegate load(suite), to: Benchee.ScenarioLoader
-
-    @doc """
-    See `Benchee.Profile.profile/1`
-    """
     defdelegate profile(suite), to: Benchee.Profile
   end
 end

--- a/lib/benchee/configuration.ex
+++ b/lib/benchee/configuration.ex
@@ -125,9 +125,12 @@ defmodule Benchee.Configuration do
     * `:measure_function_call_overhead` - Measure how long an empty function call takes and deduct this from each measure run time. Defaults to true.
     * `profile_after` - accepts any of the following options:
       * a boolean   - `true` will enable profiling with the default profiler
-      (`:cprof`) and `false` will disable profiling. Defaults to `false`.
+      (`:eprof`) and `false` will disable profiling. Defaults to `false`.
       * a profiler  - either as a tuple of `{profiler, opts}` (e.g., `{:fprof, [sort: :own]}`)
-      or just the profiler, which is equivalent to `{profiler, []}`.
+      or just the profiler (e.g., `:fprof`), which is equivalent to `{profiler, []}`. The accepted built-in profilers are
+      [`:cprof`](https://hexdocs.pm/mix/Mix.Tasks.Profile.Cprof.html),
+      [`:eprof`](https://hexdocs.pm/mix/Mix.Tasks.Profile.Eprof.html) and
+      [`:fprof`](https://hexdocs.pm/mix/Mix.Tasks.Profile.Fprof.html).
   """
   @type user_configuration :: map | keyword
 

--- a/lib/benchee/configuration.ex
+++ b/lib/benchee/configuration.ex
@@ -37,7 +37,12 @@ defmodule Benchee.Configuration do
             before_scenario: nil,
             after_scenario: nil,
             measure_function_call_overhead: true,
-            title: nil
+            title: nil,
+            profile: %{
+              profile_after: false,
+              profiler: :cprof,
+              profiler_opts: []
+            }
 
   @typedoc """
   The configuration supplied by the user as either a map or a keyword list
@@ -122,6 +127,14 @@ defmodule Benchee.Configuration do
       equivalent to the behaviour Benchee had pre 0.5.0)
     * `:before_scenario`/`after_scenario`/`before_each`/`after_each` - read up on them in the hooks section in the README
     * `:measure_function_call_overhead` - Measure how long an empty function call takes and deduct this from each measure run time. Defaults to true.
+    * `profile` - a map of options to enable profiling after each benchmark
+    containing the following keys:
+      * `profiler_after`  - either `true` or `false` to enable/disable the profiler,
+      defaults to `false`.
+      * `profiler`        - one of the built-in profilers to use (either `:cprof`,
+      `:eprof` or `:fprof`), defaults to `:cprof`.
+      * `profiler_opts`   - the option list to pass to the `profile/2` function
+      of the profiler (for more information read the documentation of each profiler).
   """
   @type user_configuration :: map | keyword
 
@@ -150,7 +163,12 @@ defmodule Benchee.Configuration do
           before_scenario: Hooks.hook_function() | nil,
           after_scenario: Hooks.hook_function() | nil,
           measure_function_call_overhead: boolean,
-          title: String.t() | nil
+          title: String.t() | nil,
+          profile: %{
+            profile_after: boolean,
+            profiler: :cprof | :eprof | :fprof,
+            profiler_opts: list
+          }
         }
 
   @time_keys [:time, :warmup, :memory_time, :reduction_time]

--- a/lib/benchee/configuration.ex
+++ b/lib/benchee/configuration.ex
@@ -38,11 +38,7 @@ defmodule Benchee.Configuration do
             after_scenario: nil,
             measure_function_call_overhead: true,
             title: nil,
-            profile: %{
-              profile_after: false,
-              profiler: :cprof,
-              profiler_opts: []
-            }
+            profile_after: false
 
   @typedoc """
   The configuration supplied by the user as either a map or a keyword list
@@ -127,14 +123,11 @@ defmodule Benchee.Configuration do
       equivalent to the behaviour Benchee had pre 0.5.0)
     * `:before_scenario`/`after_scenario`/`before_each`/`after_each` - read up on them in the hooks section in the README
     * `:measure_function_call_overhead` - Measure how long an empty function call takes and deduct this from each measure run time. Defaults to true.
-    * `profile` - a map of options to enable profiling after each benchmark
-    containing the following keys:
-      * `profiler_after`  - either `true` or `false` to enable/disable the profiler,
-      defaults to `false`.
-      * `profiler`        - one of the built-in profilers to use (either `:cprof`,
-      `:eprof` or `:fprof`), defaults to `:cprof`.
-      * `profiler_opts`   - the option list to pass to the `profile/2` function
-      of the profiler (for more information read the documentation of each profiler).
+    * `profile_after` - accepts any of the following options:
+      * a boolean   - `true` will enable profiling with the default profiler
+      (`:cprof`) and `false` will disable profiling. Defaults to `false`.
+      * a profiler  - either as a tuple of `{profiler, opts}` (e.g., `{:fprof, [sort: :own]}`)
+      or just the profiler, which is equivalent to `{profiler, []}`.
   """
   @type user_configuration :: map | keyword
 
@@ -164,11 +157,7 @@ defmodule Benchee.Configuration do
           after_scenario: Hooks.hook_function() | nil,
           measure_function_call_overhead: boolean,
           title: String.t() | nil,
-          profile: %{
-            profile_after: boolean,
-            profiler: :cprof | :eprof | :fprof,
-            profiler_opts: list
-          }
+          profile_after: boolean | atom | {atom, keyword}
         }
 
   @time_keys [:time, :warmup, :memory_time, :reduction_time]

--- a/lib/benchee/output/profile_printer.ex
+++ b/lib/benchee/output/profile_printer.ex
@@ -1,0 +1,10 @@
+defmodule Benchee.Output.ProfilePrinter do
+  @moduledoc false
+
+  @doc """
+  Prints a notification of which job is being profiled.
+  """
+  def profiling(name, profiler) do
+    IO.puts("\nProfiling #{name} with #{profiler}...")
+  end
+end

--- a/lib/benchee/profile.ex
+++ b/lib/benchee/profile.ex
@@ -20,10 +20,15 @@ defmodule Benchee.Profile do
   @spec profile(Suite.t()) :: Suite.t()
   def profile(suite = %{configuration: %{profile: %{profile_after: false}}}), do: suite
 
-  def profile(suite = %{configuration: %{profile: %{profiler: profiler, profiler_opts: profiler_opts}}, scenarios: scenarios}) do
+  def profile(
+        suite = %{
+          configuration: %{profile: %{profiler: profiler, profiler_opts: profiler_opts}},
+          scenarios: scenarios
+        }
+      ) do
     profiler_module = profiler_to_module(profiler)
 
-    Enum.each(scenarios, & run(&1, {profiler, profiler_module, profiler_opts}))
+    Enum.each(scenarios, &run(&1, {profiler, profiler_module, profiler_opts}))
 
     suite
   end
@@ -42,10 +47,12 @@ defmodule Benchee.Profile do
         profiler =
           profiler
           |> Atom.to_string()
-          |> String.capitalize
+          |> String.capitalize()
 
         Module.concat(Mix.Tasks.Profile, profiler)
-      false -> nil # not supported yet
+
+      false ->
+        nil
     end
   end
 

--- a/lib/benchee/profile.ex
+++ b/lib/benchee/profile.ex
@@ -1,58 +1,93 @@
 defmodule Benchee.Profile do
-  @moduledoc """
-  Profiles each scenario after benchmarking them if the `profile_after` flag is set to `true`.
-
-  The profiler that will be used is either the one set by the `profiler` option
-  in the `profile` configuration or the default one (`:cprof`). It accepts however the following
-  profiler options:
-    * `:cprof` will profile with `Mix.Task.Profile.Cprof` (useful to discover bottlenecks
-    related to function calls).
-    * `:eprof` will profile with `Mix.Task.Profile.Eprof` (useful to discover bottlenecks
-    related to time information of each function call).
-    * `:fprof` will profile with `Mix.Task.Profile.Fprof` (useful to discover bottlenecks
-    of a sequential code).
-  """
+  alias Benchee.Output.ProfilePrinter, as: Printer
   alias Benchee.Suite
+
+  defmodule Benchee.UnknownProfilerError do
+    defexception message: "error"
+  end
+
+  @moduledoc """
+  Profiles each scenario after benchmarking them if the `profile_after` option is either set to:
+    * `true`,
+    * a valid `profiler`,
+    * a tuple of a valid `profiler` and a list of options to pass to it, e.g., `{:fprof, [sort: :own]}`.
+
+  The profiler that will be used is either the one set by the `profiler_after` option or, if set to `true`,
+  the default one (`:cprof`). It accepts however the following profilers:
+    * `:cprof` will profile with `Mix.Task.Profile.Cprof`. It provides information related to the
+    number of function calls.
+    * `:eprof` will profile with `Mix.Task.Profile.Eprof`. It provides information related to the
+    time spent on each function in regard to the total execution time.
+    * `:fprof` will profile with `Mix.Task.Profile.Fprof`. It provides information related to the
+    time spent on each function, both the *total* time spent on it and the time spent on it,
+    *excluding* the time of called functions.
+  """
 
   @doc """
   Runs for each scenario found in the suite the `profile/2` function from the given profiler.
   """
+  @default_profiler :cprof
   @spec profile(Suite.t()) :: Suite.t()
-  def profile(suite = %{configuration: %{profile: %{profile_after: false}}}), do: suite
+  def profile(suite, printer \\ Printer)
+  def profile(suite = %{configuration: %{profile_after: false}}, _printer), do: suite
 
-  def profile(
-        suite = %{
-          configuration: %{profile: %{profiler: profiler, profiler_opts: profiler_opts}},
-          scenarios: scenarios
-        }
-      ) do
+  def profile(suite = %{configuration: %{profile_after: true}}, printer) do
+    config = %{suite.configuration | profile_after: {@default_profiler, []}}
+
+    %{suite | configuration: config}
+    |> do_profile(printer)
+  end
+
+  def profile(suite = %{configuration: %{profile_after: profiler}}, printer)
+      when is_tuple(profiler) do
+    do_profile(suite, printer)
+  end
+
+  def profile(suite = %{configuration: %{profile_after: profiler}}, printer) do
+    config = %{suite.configuration | profile_after: {profiler, []}}
+
+    %{suite | configuration: config}
+    |> do_profile(printer)
+  end
+
+  defp do_profile(
+         suite = %{
+           configuration: %{profile_after: {profiler, profiler_opts}},
+           scenarios: scenarios
+         },
+         printer
+       ) do
     profiler_module = profiler_to_module(profiler)
 
-    Enum.each(scenarios, &run(&1, {profiler, profiler_module, profiler_opts}))
+    Enum.each(scenarios, fn scenario ->
+      run(scenario, {profiler, profiler_module, profiler_opts}, printer)
+    end)
 
     suite
   end
 
-  defp run(%{name: name, function: fun_to_profile}, {profiler, profiler_module, profiler_opts}) do
-    IO.puts("\nProfiling #{name} with #{profiler}...")
+  defp run(
+         %{name: name, function: fun_to_profile},
+         {profiler, profiler_module, profiler_opts},
+         printer
+       ) do
+    printer.profiling(name, profiler)
     apply(profiler_module, :profile, [fun_to_profile, profiler_opts])
   end
 
   # If given a builtin profiler the function will return its proper module.
-  # In the case of an unknown profiler, it will return `nil`
-  # (which will make apply/2 crash later).
+  # In the case of an unknown profiler, it will raise an `UnknownProfilerError` exception.
   defp profiler_to_module(profiler) do
-    case is_builtin_profiler(profiler) do
-      true ->
-        profiler =
-          profiler
-          |> Atom.to_string()
-          |> String.capitalize()
+    if is_builtin_profiler(profiler) do
+      profiler =
+        profiler
+        |> Atom.to_string()
+        |> String.capitalize()
 
-        Module.concat(Mix.Tasks.Profile, profiler)
-
-      false ->
-        nil
+      Module.concat(Mix.Tasks.Profile, profiler)
+    else
+      raise Benchee.UnknownProfilerError,
+        message: "Got an unknown '#{inspect(profiler)}' built-in profiler."
     end
   end
 

--- a/lib/benchee/profile.ex
+++ b/lib/benchee/profile.ex
@@ -1,0 +1,56 @@
+defmodule Benchee.Profile do
+  @moduledoc """
+  Profiles each scenario after benchmarking them if the `profile_after` flag is set to `true`.
+
+  The profiler that will be used is either the one set by the `profiler` option
+  in the `profile` configuration or the default one (`:cprof`). It accepts however the following
+  profiler options:
+    * `:cprof` will profile with `Mix.Task.Profile.Cprof` (useful to discover bottlenecks
+    related to function calls).
+    * `:eprof` will profile with `Mix.Task.Profile.Eprof` (useful to discover bottlenecks
+    related to time information of each function call).
+    * `:fprof` will profile with `Mix.Task.Profile.Fprof` (useful to discover bottlenecks
+    of a sequential code).
+  """
+  alias Benchee.Suite
+
+  @doc """
+  Runs for each scenario found in the suite the `profile/2` function from the given profiler.
+  """
+  @spec profile(Suite.t()) :: Suite.t()
+  def profile(suite = %{configuration: %{profile: %{profile_after: false}}}), do: suite
+
+  def profile(suite = %{configuration: %{profile: %{profiler: profiler, profiler_opts: profiler_opts}}, scenarios: scenarios}) do
+    profiler_module = profiler_to_module(profiler)
+
+    Enum.each(scenarios, & run(&1, {profiler, profiler_module, profiler_opts}))
+
+    suite
+  end
+
+  defp run(%{name: name, function: fun_to_profile}, {profiler, profiler_module, profiler_opts}) do
+    IO.puts("\nProfiling #{name} with #{profiler}...")
+    apply(profiler_module, :profile, [fun_to_profile, profiler_opts])
+  end
+
+  # If given a builtin profiler the function will return its proper module.
+  # In the case of an unknown profiler, it will return `nil`
+  # (which will make apply/2 crash later).
+  defp profiler_to_module(profiler) do
+    case is_builtin_profiler(profiler) do
+      true ->
+        profiler =
+          profiler
+          |> Atom.to_string()
+          |> String.capitalize
+
+        Module.concat(Mix.Tasks.Profile, profiler)
+      false -> nil # not supported yet
+    end
+  end
+
+  defp is_builtin_profiler(:cprof), do: true
+  defp is_builtin_profiler(:eprof), do: true
+  defp is_builtin_profiler(:fprof), do: true
+  defp is_builtin_profiler(_), do: false
+end

--- a/lib/benchee/profile.ex
+++ b/lib/benchee/profile.ex
@@ -2,6 +2,9 @@ defmodule Benchee.Profile do
   alias Benchee.Output.ProfilePrinter, as: Printer
   alias Benchee.Suite
 
+  @default_profiler :eprof
+  @builtin_profilers [:cprof, :eprof, :fprof]
+
   defmodule Benchee.UnknownProfilerError do
     defexception message: "error"
   end
@@ -13,57 +16,71 @@ defmodule Benchee.Profile do
     * a tuple of a valid `profiler` and a list of options to pass to it, e.g., `{:fprof, [sort: :own]}`.
 
   The profiler that will be used is either the one set by the `profiler_after` option or, if set to `true`,
-  the default one (`:cprof`). It accepts however the following profilers:
-    * `:cprof` will profile with `Mix.Task.Profile.Cprof`. It provides information related to the
-    number of function calls.
-    * `:eprof` will profile with `Mix.Task.Profile.Eprof`. It provides information related to the
-    time spent on each function in regard to the total execution time.
-    * `:fprof` will profile with `Mix.Task.Profile.Fprof`. It provides information related to the
-    time spent on each function, both the *total* time spent on it and the time spent on it,
+  the default one (`:eprof`). It accepts however the following profilers:
+    * `:cprof` will profile with [`Mix.Task.Profile.Cprof`](https://hexdocs.pm/mix/Mix.Tasks.Profile.Cprof.html).
+    It provides information related to the number of function calls.
+    * `:eprof` will profile with [`Mix.Task.Profile.Eprof`](https://hexdocs.pm/mix/Mix.Tasks.Profile.Eprof.html).
+    It provides information related to the time spent on each function in regard to the total execution time.
+    * `:fprof` will profile with [`Mix.Task.Profile.Fprof`](https://hexdocs.pm/mix/Mix.Tasks.Profile.Cprof.html).
+    It provides information related to the time spent on each function, both the *total* time spent on it and the time spent on it,
     *excluding* the time of called functions.
   """
 
   @doc """
+  Returns the atom corresponding to the default profiler.
+  """
+  @spec default_profiler() :: unquote(@default_profiler)
+  def default_profiler, do: @default_profiler
+
+  @doc """
   Runs for each scenario found in the suite the `profile/2` function from the given profiler.
   """
-  @default_profiler :cprof
-  @spec profile(Suite.t()) :: Suite.t()
+  @spec profile(Suite.t(), module) :: Suite.t()
   def profile(suite, printer \\ Printer)
   def profile(suite = %{configuration: %{profile_after: false}}, _printer), do: suite
 
-  def profile(suite = %{configuration: %{profile_after: true}}, printer) do
-    config = %{suite.configuration | profile_after: {@default_profiler, []}}
+  def profile(
+        suite = %{
+          scenarios: scenarios,
+          configuration: %{profile_after: true}
+        },
+        printer
+      ) do
+    do_profile(scenarios, {@default_profiler, []}, printer)
 
-    %{suite | configuration: config}
-    |> do_profile(printer)
+    suite
   end
 
-  def profile(suite = %{configuration: %{profile_after: profiler}}, printer)
-      when is_tuple(profiler) do
-    do_profile(suite, printer)
+  def profile(
+        suite = %{
+          scenarios: scenarios,
+          configuration: %{profile_after: {profiler, profiler_opts}}
+        },
+        printer
+      ) do
+    do_profile(scenarios, {profiler, profiler_opts}, printer)
+
+    suite
   end
 
-  def profile(suite = %{configuration: %{profile_after: profiler}}, printer) do
-    config = %{suite.configuration | profile_after: {profiler, []}}
+  def profile(
+        suite = %{
+          scenarios: scenarios,
+          configuration: %{profile_after: profiler}
+        },
+        printer
+      ) do
+    do_profile(scenarios, {profiler, []}, printer)
 
-    %{suite | configuration: config}
-    |> do_profile(printer)
+    suite
   end
 
-  defp do_profile(
-         suite = %{
-           configuration: %{profile_after: {profiler, profiler_opts}},
-           scenarios: scenarios
-         },
-         printer
-       ) do
+  defp do_profile(scenarios, {profiler, profiler_opts}, printer) do
     profiler_module = profiler_to_module(profiler)
 
     Enum.each(scenarios, fn scenario ->
       run(scenario, {profiler, profiler_module, profiler_opts}, printer)
     end)
-
-    suite
   end
 
   defp run(
@@ -78,7 +95,7 @@ defmodule Benchee.Profile do
   # If given a builtin profiler the function will return its proper module.
   # In the case of an unknown profiler, it will raise an `UnknownProfilerError` exception.
   defp profiler_to_module(profiler) do
-    if is_builtin_profiler(profiler) do
+    if Enum.member?(@builtin_profilers, profiler) do
       profiler =
         profiler
         |> Atom.to_string()
@@ -90,9 +107,4 @@ defmodule Benchee.Profile do
         message: "Got an unknown '#{inspect(profiler)}' built-in profiler."
     end
   end
-
-  defp is_builtin_profiler(:cprof), do: true
-  defp is_builtin_profiler(:eprof), do: true
-  defp is_builtin_profiler(:fprof), do: true
-  defp is_builtin_profiler(_), do: false
 end

--- a/samples/fast_with_profiling.ex
+++ b/samples/fast_with_profiling.ex
@@ -1,0 +1,85 @@
+list = Enum.to_list(1..10_000)
+map_fun = fn i -> [i, i * i] end
+
+Benchee.run(
+  %{
+    "flat_map" => fn -> Enum.flat_map(list, map_fun) end,
+    "map.flatten" => fn -> list |> Enum.map(map_fun) |> List.flatten() end
+  },
+  warmup: 0.1,
+  time: 0.3,
+  memory_time: 0.3,
+  profile: [
+    profile_after: true
+  ]
+)
+
+# Operating System: Linux
+# CPU Information: Intel(R) Core(TM) i5-7200U CPU @ 2.50GHz
+# Number of Available Cores: 4
+# Available memory: 7.67 GB
+# Elixir 1.10.0
+# Erlang 22.2.4
+
+# Benchmark suite executing with the following configuration:
+# warmup: 100 ms
+# time: 300 ms
+# memory time: 300 ms
+# reduction time: 0 ns
+# parallel: 1
+# inputs: none specified
+# Estimated total run time: 1.40 s
+
+# Benchmarking flat_map...
+# Benchmarking map.flatten...
+
+# Name                  ips        average  deviation         median         99th %
+# flat_map           1.43 K      699.04 μs    ±39.78%      596.65 μs     1161.17 μs
+# map.flatten        1.01 K      987.44 μs    ±22.65%      929.69 μs     1576.78 μs
+
+# Comparison:
+# flat_map           1.43 K
+# map.flatten        1.01 K - 1.41x slower +288.40 μs
+
+# Memory usage statistics:
+
+# Name           Memory usage
+# flat_map             625 KB
+# map.flatten       781.25 KB - 1.25x memory usage +156.25 KB
+
+# **All measurements for memory usage were the same**
+
+# Profiling flat_map with cprof...
+# Warmup...
+
+#                                                                      CNT
+# Total                                                              20005
+# Enum                                                               10002  <--
+#   Enum.flat_map_list/2                                             10001
+#   Enum.flat_map/2                                                      1
+# :elixir_compiler_1                                                 10001  <--
+#   anonymous fn/1 in :elixir_compiler_1.__FILE__/1                  10000
+#   anonymous fn/2 in :elixir_compiler_1.__FILE__/1                      1
+# :erlang                                                                2  <--
+#   :erlang.trace_pattern/3                                              2
+# Profile done over 18327 matching functions
+
+# Profiling map.flatten with cprof...
+# Warmup...
+
+#                                                                      CNT
+# Total                                                              60008
+# :lists                                                             40002  <--
+#   :lists.do_flatten/2                                              40001
+#   :lists.flatten/1                                                     1
+# Enum                                                               10002  <--
+#   Enum."-map/2-lists^map/1-0-"/2                                   10001
+#   Enum.map/2                                                           1
+# :elixir_compiler_1                                                 10001  <--
+#   anonymous fn/1 in :elixir_compiler_1.__FILE__/1                  10000
+#   anonymous fn/2 in :elixir_compiler_1.__FILE__/1                      1
+# :erlang                                                                2  <--
+#   :erlang.trace_pattern/3                                              2
+# List                                                                   1  <--
+#   List.flatten/1                                                       1
+# Profile done over 18394 matching functions

--- a/samples/fast_with_profiling.ex
+++ b/samples/fast_with_profiling.ex
@@ -9,9 +9,7 @@ Benchee.run(
   warmup: 0.1,
   time: 0.3,
   memory_time: 0.3,
-  profile: [
-    profile_after: true
-  ]
+  profile_after: true
 )
 
 # Operating System: Linux

--- a/test/benchee/profile_test.exs
+++ b/test/benchee/profile_test.exs
@@ -1,0 +1,100 @@
+defmodule Benchee.ProfileTest do
+  # async is set to false because otherwise testing the profilers might lead to failures
+  use ExUnit.Case, async: false
+
+  alias Benchee.{
+    Benchmark,
+    Configuration,
+    Profile,
+    Suite
+  }
+
+  alias Benchee.Test.FakeProfilePrinter, as: TestPrinter
+
+  import ExUnit.CaptureIO
+
+  @config_with_profiler %Configuration{profile_after: true}
+
+  describe ".profile" do
+    test "`profile_after` defaults to false, which doesnt profile" do
+      %{configuration: %{profile_after: profile_after}} = suite = %Suite{}
+
+      output =
+        capture_io(fn ->
+          suite
+          |> Benchmark.benchmark("one job", fn -> 1 end)
+          |> Profile.profile()
+        end)
+
+      refute output =~ "Profiling"
+      refute profile_after
+    end
+
+    test "can profile a benchmark" do
+      output =
+        capture_io(fn ->
+          %Suite{configuration: @config_with_profiler}
+          |> Benchmark.benchmark("one job", fn -> 1 end)
+          |> Profile.profile()
+        end)
+
+      assert output =~ "Profiling"
+    end
+
+    test "will not profile if no benchmark is found" do
+      output =
+        capture_io(fn ->
+          %Suite{configuration: @config_with_profiler}
+          |> Profile.profile()
+        end)
+
+      assert output =~ ""
+    end
+
+    test "accepts profiler options" do
+      configuration = %Configuration{profile_after: profiler_with_opts()}
+
+      output =
+        capture_io(fn ->
+          %Suite{configuration: configuration}
+          |> Benchmark.benchmark("one job", fn -> 1 end)
+          |> Profile.profile()
+        end)
+
+      assert output =~ ~r/Profiling one job with fprof/
+      assert output =~ ~r/CNT.+ACC \(ms\).+OWN \(ms\)/
+    end
+
+    test "sends the correct data to the profile printer" do
+      name = "one job"
+      profiler = :cprof
+      configuration = %Configuration{profile_after: profiler}
+
+      capture_io(fn ->
+        %Suite{configuration: configuration}
+        |> Benchmark.benchmark(name, fn -> 1 end)
+        |> Profile.profile(TestPrinter)
+      end)
+
+      assert_receive {:profiling, ^name, ^profiler}
+    end
+  end
+
+  # The example of {:fprof, [sort: :own]} crashes in Elixir version
+  # prior to 1.7 because back then they didn't use the atom `:own`
+  # but rather its string counterpart.
+  #
+  # The `accepts profiler options` test should be changed to use
+  # the commented `@profile_with_opts` attribute when benchee
+  # requires at least Elixir 1.7
+  defp profiler_with_opts do
+    sort_option =
+      if Version.match?(System.version(), ">= 1.7.0") do
+        :own
+      else
+        "own"
+      end
+
+    {:fprof, [sort: sort_option]}
+  end
+end

--- a/test/benchee_test.exs
+++ b/test/benchee_test.exs
@@ -5,6 +5,7 @@ defmodule BencheeTest do
     Conversion.Duration,
     Formatter,
     Formatters.Console,
+    Profile,
     Profile.Benchee.UnknownProfilerError,
     Statistics,
     Suite,
@@ -226,23 +227,16 @@ defmodule BencheeTest do
     refute output =~ ~r/compar/i
   end
 
-  test "integration profiling can be deactivated" do
+  test "integration profiling defaults to no profile" do
     output =
       capture_io(fn ->
-        Benchee.run(
-          %{"Sleeps" => fn -> :timer.sleep(10) end},
-          Keyword.merge(
-            @test_configuration,
-            profile_after: false
-          )
-        )
+        Benchee.run(%{"Sleeps" => fn -> :timer.sleep(10) end})
       end)
 
-    refute output =~ ~r/Profiling.+with/
-    refute output =~ ~r/Profile done/
+    refute output =~ ~r/Profiling.+with/i
+    refute output =~ ~r/Profile done/i
   end
 
-  @default_profiler :cprof
   test "integration profiling `profile_after: true` runs default profiler" do
     output =
       capture_io(fn ->
@@ -255,8 +249,8 @@ defmodule BencheeTest do
         )
       end)
 
-    assert output =~ profiling_regex("Sleeps", @default_profiler)
-    assert output =~ end_of_profiling_regex(@default_profiler)
+    assert output =~ profiling_regex("Sleeps", Profile.default_profiler())
+    assert output =~ end_of_profiling_regex(Profile.default_profiler())
   end
 
   @profilers [:cprof, :eprof, :fprof]

--- a/test/benchee_test.exs
+++ b/test/benchee_test.exs
@@ -5,6 +5,7 @@ defmodule BencheeTest do
     Conversion.Duration,
     Formatter,
     Formatters.Console,
+    Profile.Benchee.UnknownProfilerError,
     Statistics,
     Suite,
     Test.FakeFormatter
@@ -223,6 +224,73 @@ defmodule BencheeTest do
       end)
 
     refute output =~ ~r/compar/i
+  end
+
+  test "integration profiling can be deactivated" do
+    output =
+      capture_io(fn ->
+        Benchee.run(
+          %{"Sleeps" => fn -> :timer.sleep(10) end},
+          Keyword.merge(
+            @test_configuration,
+            profile_after: false
+          )
+        )
+      end)
+
+    refute output =~ ~r/Profiling.+with/
+    refute output =~ ~r/Profile done/
+  end
+
+  @default_profiler :cprof
+  test "integration profiling `profile_after: true` runs default profiler" do
+    output =
+      capture_io(fn ->
+        Benchee.run(
+          %{"Sleeps" => fn -> :timer.sleep(10) end},
+          Keyword.merge(
+            @test_configuration,
+            profile_after: true
+          )
+        )
+      end)
+
+    assert output =~ profiling_regex("Sleeps", @default_profiler)
+    assert output =~ end_of_profiling_regex(@default_profiler)
+  end
+
+  @profilers [:cprof, :eprof, :fprof]
+  for profiler <- @profilers do
+    @profiler profiler
+    test "integration profiling runs #{inspect(@profiler)} profiler" do
+      output =
+        capture_io(fn ->
+          Benchee.run(
+            %{"Sleeps" => fn -> :timer.sleep(10) end},
+            Keyword.merge(
+              @test_configuration,
+              profile_after: @profiler
+            )
+          )
+        end)
+
+      assert output =~ profiling_regex("Sleeps", @profiler)
+      assert output =~ end_of_profiling_regex(@profiler)
+    end
+  end
+
+  test "integration profiling a wrong profiler raises exception" do
+    assert_raise UnknownProfilerError, fn ->
+      capture_io(fn ->
+        Benchee.run(
+          %{"Sleeps" => fn -> :timer.sleep(10) end},
+          Keyword.merge(
+            @test_configuration,
+            profile_after: :cproff
+          )
+        )
+      end)
+    end
   end
 
   test "multiple formatters can be configured and are all called" do
@@ -848,6 +916,20 @@ defmodule BencheeTest do
 
   defp body_regex(benchmark_name, tag_regex \\ "") do
     ~r/^#{benchmark_name}#{tag_regex}\s+\d+.+\s+\d+\.?\d*.+\s+.+\d+\.?\d*.+\s+\d+\.?\d*.+/m
+  end
+
+  defp profiling_regex(benchmark_name, profiler) do
+    ~r/Profiling #{benchmark_name} with #{profiler}/
+  end
+
+  # :fprof is the only profiler who doesn't have at the end of its output:
+  # "Profile done over X matching functions"
+  defp end_of_profiling_regex(:fprof) do
+    ~r/CNT.+ACC \(ms\).+OWN \(ms\)/
+  end
+
+  defp end_of_profiling_regex(_profiler) do
+    ~r/Profile done/
   end
 
   defp windows? do

--- a/test/support/fake_profile_printer.ex
+++ b/test/support/fake_profile_printer.ex
@@ -1,0 +1,7 @@
+defmodule Benchee.Test.FakeProfilePrinter do
+  @moduledoc false
+
+  def profiling(name, profiler) do
+    send(self(), {:profiling, name, profiler})
+  end
+end


### PR DESCRIPTION
Enable profiling after benchmarking with the addition of a `profile`
configuration option. It's a map containing:
  * `profile_after`, which if set to `true` will enable the profiling
  * `profiler`, to set the buit-in profiler to use (:cprof, :eprof, :fprof)
  * `profiler_opts`, a list of profiler-specific options to pass to the profiler

Closes #250.

TO-DO:
* [x] First draft of the code
* [x] Add documentation
* [x] Add tests
* [x] Add a sample with profiling enabled (for now I copied `fast.exs` and updated and example of its output)
* [x] Run the mix formatter (didn't see that CI would fail otherwise)
* [x] Update the `Configuration` section in the README.md to reflect this changes