### PR TITLE
Add OTP 23 to test matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,14 +12,15 @@ jobs:
 
     strategy:
       matrix:
-        elixir_version: ['1.6.6', '1.7.4', '1.8.2', '1.9.4', '1.10.3']
-        otp_version: ['20.3', '21.3', '22.3']
-        include:
-          - elixir_version: '1.6.6'
-            otp_version: '19.3'
+        elixir_version: ['1.7.4', '1.8.2', '1.9.4', '1.10.3']
+        otp_version: ['20.3', '21.3', '22.3', '23.1']
         exclude:
-          - elixir_version: '1.6.6'
-            otp_version: '22.3'
+          - elixir_version: '1.7.4'
+            otp_version: '23.1'
+          - elixir_version: '1.8.2'
+            otp_version: '23.1'
+          - elixir_version: '1.9.4'
+            otp_version: '23.1'
           - elixir_version: '1.10.3'
             otp_version: '20.3'
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.10.3-otp-22
-erlang 22.3
+elixir 1.11.0-rc.0-otp-23
+erlang 23.0.2

--- a/README.md
+++ b/README.md
@@ -134,7 +134,9 @@ end
 
 Install via `mix deps.get` and then happy benchmarking as described in [Usage](#usage) :)
 
-Elixir versions supported/tested against are 1.6+. It _should_ theoretically still work with 1.4 & 1.5 but we don't actively test/support it.
+Elixir versions supported/tested against are 1.7+. It _should_ theoretically still work with 1.4,
+1.5 and 1.6 but we don't actively test/support it these versions as they're no longer [maintained
+by the Elixir team](https://hexdocs.pm/elixir/master/compatibility-and-deprecations.html).
 
 ## Usage
 

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Benchee.Mixfile do
     [
       app: :benchee,
       version: @version,
-      elixir: "~> 1.6",
+      elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       consolidate_protocols: true,
       build_embedded: Mix.env() == :prod,


### PR DESCRIPTION
This adds OTP 23 to our test matrix, and also bumps the versions for
development to 1.11.0-rc.0 and to OTP 23. Looks like everything is still
green (although we've got a deprecation that might need to be worked out
at one point where we're still using `System.stacktrace/0`).