### PR TITLE
fix: stacktrace deprecation

### DIFF
--- a/lib/benchee/benchmark/collect/memory.ex
+++ b/lib/benchee/benchmark/collect/memory.ex
@@ -57,7 +57,12 @@ defmodule Benchee.Benchmark.Collect.Memory do
           # would love to have this in a separate function, but elixir 1.7 complains
           send(tracer, :done)
           send(parent, {ref, :shutdown})
-          stacktrace = __STACKTRACE__
+
+          stacktrace =
+            if Version.compare(System.version(), "1.7.0") == :gt,
+              do: __STACKTRACE__,
+              else: System.stacktrace()
+
           IO.puts(Exception.format(kind, reason, stacktrace))
           exit(:normal)
       after

--- a/lib/benchee/benchmark/collect/memory.ex
+++ b/lib/benchee/benchmark/collect/memory.ex
@@ -16,7 +16,7 @@ defmodule Benchee.Benchmark.Collect.Memory do
   @behaviour Benchee.Benchmark.Collect
 
   defmacro compatible_stacktrace do
-    if Version.compare(Version.parse!(System.version()), Version.parse!("1.7.0")) == :gt do
+    if Version.match?(Version.parse!(System.version()), "~> 1.7") do
       quote do
         __STACKTRACE__
       end

--- a/lib/benchee/benchmark/collect/memory.ex
+++ b/lib/benchee/benchmark/collect/memory.ex
@@ -57,7 +57,7 @@ defmodule Benchee.Benchmark.Collect.Memory do
           # would love to have this in a separate function, but elixir 1.7 complains
           send(tracer, :done)
           send(parent, {ref, :shutdown})
-          stacktrace = System.stacktrace()
+          stacktrace = __STACKTRACE__
           IO.puts(Exception.format(kind, reason, stacktrace))
           exit(:normal)
       after

--- a/lib/benchee/benchmark/collect/memory.ex
+++ b/lib/benchee/benchmark/collect/memory.ex
@@ -15,7 +15,7 @@ defmodule Benchee.Benchmark.Collect.Memory do
 
   @behaviour Benchee.Benchmark.Collect
 
-  defmacro compatible_stacktrace do
+  defmacrop compatible_stacktrace do
     if Version.match?(Version.parse!(System.version()), "~> 1.7") do
       quote do
         __STACKTRACE__


### PR DESCRIPTION
Fixes deprecation warning:
`System.stacktrace/0 is deprecated, use __STACKTRACE__ instead`