### PR TITLE
Add space before ellipsis

### DIFF
--- a/lib/benchee/output/benchmark_printer.ex
+++ b/lib/benchee/output/benchmark_printer.ex
@@ -86,7 +86,7 @@ defmodule Benchee.Output.BenchmarkPrinter do
     do: nil
 
   def benchmarking(name, input_name, _config) do
-    IO.puts("Benchmarking #{name}#{input_information(input_name)}...")
+    IO.puts("Benchmarking #{name}#{input_information(input_name)} ...")
   end
 
   @no_input Benchmark.no_input()


### PR DESCRIPTION
It confuses me because it looks like map_100 is trimmed.

Benchmarking first: Map.get with input map_100...

Now it looks:

Benchmarking first: Map.get with input map_100 ...