### PR TITLE
Warn if the benchmarking function is evaluating

### DIFF
--- a/lib/benchee.ex
+++ b/lib/benchee.ex
@@ -40,6 +40,7 @@ for {module, moduledoc} <- [{Benchee, elixir_doc}, {:benchee, erlang_doc}] do
         )
     """
     @spec run(map, keyword) :: any
+
     def run(jobs, config \\ []) when is_list(config) do
       config
       |> Benchee.init()
@@ -55,6 +56,11 @@ for {module, moduledoc} <- [{Benchee, elixir_doc}, {:benchee, erlang_doc}] do
 
     defp add_benchmarking_jobs(suite, jobs) do
       Enum.reduce(jobs, suite, fn {key, function}, suite_acc ->
+        if :erlang.fun_info(function, :module) == {:module, :erl_eval} do
+          "warning: the benchmark #{key} is using an evaluated function. Evaluated functions perform slower than compiled functions. Consider moving all of the Benchee caller to a function in a module and invoking the `Mod.fun()` instead."
+          |> IO.puts()
+        end
+
         Benchee.benchmark(suite_acc, key, function)
       end)
     end

--- a/lib/benchee.ex
+++ b/lib/benchee.ex
@@ -55,14 +55,6 @@ for {module, moduledoc} <- [{Benchee, elixir_doc}, {:benchee, erlang_doc}] do
 
     defp add_benchmarking_jobs(suite, jobs) do
       Enum.reduce(jobs, suite, fn {key, function}, suite_acc ->
-        if is_function(function) && :erlang.fun_info(function, :module) == {:module, :erl_eval} do
-          IO.puts("""
-          Warning: the benchmark #{key} is using an evaluated function.
-            Evaluated functions perform slower than compiled functions.
-            Consider moving all of the Benchee caller to a function in a module and invoking the `Mod.fun()` instead.
-          """)
-        end
-
         Benchee.benchmark(suite_acc, key, function)
       end)
     end

--- a/lib/benchee.ex
+++ b/lib/benchee.ex
@@ -55,7 +55,7 @@ for {module, moduledoc} <- [{Benchee, elixir_doc}, {:benchee, erlang_doc}] do
 
     defp add_benchmarking_jobs(suite, jobs) do
       Enum.reduce(jobs, suite, fn {key, function}, suite_acc ->
-        if :erlang.fun_info(function, :module) == {:module, :erl_eval} do
+        if is_function(function) && :erlang.fun_info(function, :module) == {:module, :erl_eval} do
           IO.puts("""
           Warning: the benchmark #{key} is using an evaluated function.
             Evaluated functions perform slower than compiled functions.

--- a/lib/benchee.ex
+++ b/lib/benchee.ex
@@ -40,7 +40,6 @@ for {module, moduledoc} <- [{Benchee, elixir_doc}, {:benchee, erlang_doc}] do
         )
     """
     @spec run(map, keyword) :: any
-
     def run(jobs, config \\ []) when is_list(config) do
       config
       |> Benchee.init()
@@ -57,7 +56,11 @@ for {module, moduledoc} <- [{Benchee, elixir_doc}, {:benchee, erlang_doc}] do
     defp add_benchmarking_jobs(suite, jobs) do
       Enum.reduce(jobs, suite, fn {key, function}, suite_acc ->
         if :erlang.fun_info(function, :module) == {:module, :erl_eval} do
-          IO.puts("warning: the benchmark #{key} is using an evaluated function. Evaluated functions perform slower than compiled functions. Consider moving all of the Benchee caller to a function in a module and invoking the `Mod.fun()` instead.")
+          IO.puts("""
+          Warning: the benchmark #{key} is using an evaluated function.
+            Evaluated functions perform slower than compiled functions.
+            Consider moving all of the Benchee caller to a function in a module and invoking the `Mod.fun()` instead.
+          """)
         end
 
         Benchee.benchmark(suite_acc, key, function)

--- a/lib/benchee.ex
+++ b/lib/benchee.ex
@@ -57,8 +57,7 @@ for {module, moduledoc} <- [{Benchee, elixir_doc}, {:benchee, erlang_doc}] do
     defp add_benchmarking_jobs(suite, jobs) do
       Enum.reduce(jobs, suite, fn {key, function}, suite_acc ->
         if :erlang.fun_info(function, :module) == {:module, :erl_eval} do
-          "warning: the benchmark #{key} is using an evaluated function. Evaluated functions perform slower than compiled functions. Consider moving all of the Benchee caller to a function in a module and invoking the `Mod.fun()` instead."
-          |> IO.puts()
+          IO.puts("warning: the benchmark #{key} is using an evaluated function. Evaluated functions perform slower than compiled functions. Consider moving all of the Benchee caller to a function in a module and invoking the `Mod.fun()` instead.")
         end
 
         Benchee.benchmark(suite_acc, key, function)

--- a/lib/benchee/benchmark.ex
+++ b/lib/benchee/benchmark.ex
@@ -24,14 +24,33 @@ defmodule Benchee.Benchmark do
   function for each input.
   """
   @spec benchmark(Suite.t(), Suite.key(), Scenario.benchmarking_function(), module) :: Suite.t()
-  def benchmark(suite = %Suite{scenarios: scenarios}, job_name, function, printer \\ Printer) do
+  def benchmark(
+        suite = %Suite{scenarios: scenarios},
+        job_name,
+        to_be_benchmark,
+        printer \\ Printer
+      ) do
+    warn_if_evaluated(to_be_benchmark, job_name, printer)
+
     normalized_name = to_string(job_name)
 
     if duplicate?(scenarios, normalized_name) do
       printer.duplicate_benchmark_warning(normalized_name)
       suite
     else
-      add_scenario(suite, normalized_name, function)
+      add_scenario(suite, normalized_name, to_be_benchmark)
+    end
+  end
+
+  defp warn_if_evaluated(to_be_benchmark, job_name, printer) do
+    function =
+      case to_be_benchmark do
+        {function, _} -> function
+        function -> function
+      end
+
+    if :erlang.fun_info(function, :module) == {:module, :erl_eval} do
+      printer.evaluated_function_warning(job_name)
     end
   end
 

--- a/lib/benchee/output/benchmark_printer.ex
+++ b/lib/benchee/output/benchmark_printer.ex
@@ -4,6 +4,20 @@ defmodule Benchee.Output.BenchmarkPrinter do
   alias Benchee.{Benchmark, Conversion.Duration}
 
   @doc """
+  Shown when you try benchmark an evaluated function.
+
+  Compiled functions should be preferred as they are less likely to introduce additional overhead to your benchmark timing.
+  """
+  def evaluated_function_warning(job_name) do
+    IO.puts("""
+    Warning: the benchmark #{job_name} is using an evaluated function.
+      Evaluated functions perform slower than compiled functions.
+      You can move the Benchee caller to a function in a module and invoke `Mod.fun()` instead.
+      Alternatively, you can move the benchmark into a benchmark.exs file and run mix run benchmark.exs
+    """)
+  end
+
+  @doc """
   Shown when you try to define a benchmark with the same name twice.
 
   How would you want to discern those anyhow?


### PR DESCRIPTION
First time contributing to benchee, please let me know how I can improve this PR! 🙏

This was done in a group with @czrpb, @aar2dee2, and @ReecesPeanutButterCodes.

Attempting to warn if the benchmarking function is evaluated instead of compiled based on #355 .

We were not sure how to best present the warning, and could not find previous examples to follow. Please let me know if there
is a better way than a multiline `IO.puts`

![image](https://user-images.githubusercontent.com/14877564/167270220-a961814b-1524-4c00-a066-c55a5076ac58.png)

We opted to only handle when the benchmarked function is a function, rather than when it's a tuple.

Resolves #355 