### PR TITLE
Fallback to otp_release when OTP_VERSION is unavailable

### DIFF
--- a/lib/benchee/system.ex
+++ b/lib/benchee/system.ex
@@ -37,8 +37,8 @@ defmodule Benchee.System do
       {:ok, version} ->
         String.trim(version)
 
-      {:error, reason} ->
-        IO.puts("Error trying to determine erlang version #{reason}")
+      {:error, _reason} ->
+        to_string(otp_release)
     end
   end
 


### PR DESCRIPTION
closes #367 

Because this PR is so small I add a cat pic.
![klara](https://user-images.githubusercontent.com/223263/183300439-9e0528b4-38bc-411c-bdd2-f57a0d0aedba.png)
