### PR TITLE
Implement human friendlier formatting for `Benchee.Conversion.Duration`

### DIFF
--- a/lib/benchee/conversion/duration.ex
+++ b/lib/benchee/conversion/duration.ex
@@ -307,7 +307,7 @@ defmodule Benchee.Conversion.Duration do
   defp place_values(number, [base_unit]), do: [{number, base_unit}]
 
   defp place_values(number, [unit | units]) do
-    place_value = floor(number)
+    place_value = trunc(number)
     decimal_carry = number - place_value
     int_carry = rem(place_value, unit.magnitude)
 

--- a/lib/benchee/conversion/format.ex
+++ b/lib/benchee/conversion/format.ex
@@ -24,10 +24,14 @@ defmodule Benchee.Conversion.Format do
     "#{number_format(count)}#{separator}#{label}"
   end
 
-  defp number_format(count) do
+  defp number_format(count) when is_float(count) do
     count
     |> :erlang.float_to_list(decimals: float_precision(count))
     |> to_string
+  end
+
+  defp number_format(count) when is_integer(count) do
+    to_string(count)
   end
 
   @doc """
@@ -57,7 +61,7 @@ defmodule Benchee.Conversion.Format do
     format({count, module.unit_for(unit_atom)})
   end
 
-  def format(number, module) do
+  def format(number, module) when is_number(number) do
     number
     |> module.scale()
     |> format

--- a/lib/benchee/conversion/scale.ex
+++ b/lib/benchee/conversion/scale.ex
@@ -17,14 +17,14 @@ defmodule Benchee.Conversion.Scale do
   @doc """
   Scales a number in a domain's base unit to an equivalent value in the best
   fit unit. Results are a `{number, unit}` tuple. See `Benchee.Conversion.Count` and
-  `Benchee.Conversion.Duration` for examples
+  `Benchee.Conversion.Duration` for examples.
   """
   @callback scale(number) :: scaled_number
 
   @doc """
   Scales a number in a domain's base unit to an equivalent value in the
-  specified unit. Results are a `{number, unit}` tuple. See
-  `Benchee.Conversion.Count` and `Benchee.Conversion.Duration` for examples
+  specified unit.
+  See `Benchee.Conversion.Count` and `Benchee.Conversion.Duration` for examples.
   """
   @callback scale(number, any_unit) :: number
 

--- a/lib/benchee/output/benchmark_printer.ex
+++ b/lib/benchee/output/benchmark_printer.ex
@@ -73,13 +73,13 @@ defmodule Benchee.Output.BenchmarkPrinter do
 
     IO.puts("""
     Benchmark suite executing with the following configuration:
-    warmup: #{Duration.format(warmup)}
-    time: #{Duration.format(time)}
-    memory time: #{Duration.format(memory_time)}
-    reduction time: #{Duration.format(reduction_time)}
+    warmup: #{Duration.format_verbose(warmup)}
+    time: #{Duration.format_verbose(time)}
+    memory time: #{Duration.format_verbose(memory_time)}
+    reduction time: #{Duration.format_verbose(reduction_time)}
     parallel: #{parallel}
     inputs: #{inputs_out(inputs)}
-    Estimated total run time: #{Duration.format(total_time)}
+    Estimated total run time: #{Duration.format_verbose(total_time)}
     """)
   end
 

--- a/test/benchee/conversion/duration_test.exs
+++ b/test/benchee/conversion/duration_test.exs
@@ -24,19 +24,19 @@ defmodule Benchee.Conversion.DurationTest do
       assert format(987_654.321) == "987.65 μs"
     end
 
-    test ".format(9_876_543210)" do
+    test ".format(9_876_543_210)" do
       assert format(9_876_543_210) == "9.88 s"
     end
 
-    test ".format(98_765_432190)" do
+    test ".format(98_765_432_190)" do
       assert format(98_765_432_190) == "1.65 min"
     end
 
-    test ".format(987_654_321987.6)" do
+    test ".format(987_654_321_987.6)" do
       assert format(987_654_321_987.6) == "16.46 min"
     end
 
-    test ".format(9_876_543_219876.5)" do
+    test ".format(9_876_543_219_876.5)" do
       assert format(9_876_543_219_876.5) == "2.74 h"
     end
 
@@ -46,6 +46,72 @@ defmodule Benchee.Conversion.DurationTest do
 
     test ".format(0)" do
       assert format(0) == "0 ns"
+    end
+  end
+
+  describe ".format_verbose" do
+    test ".format_verbose(0)" do
+      assert format_verbose(0) == "0 ns"
+    end
+
+    test ".format_verbose(0.00)" do
+      assert format_verbose(0.00) == "0 ns"
+    end
+
+    test ".format_verbose(98.7654321)" do
+      assert format_verbose(98.7654321) == "98.77 ns"
+    end
+
+    test ".format_verbose(523.0)" do
+      assert format_verbose(523.0) == "523 ns"
+    end
+
+    test ".format_verbose(987.654321)" do
+      assert format_verbose(987.654321) == "987.65 ns"
+    end
+
+    test ".format_verbose(9_008)" do
+      assert format_verbose(9_008) == "9 μs 8 ns"
+    end
+
+    test ".format_verbose(9_876.54321)" do
+      assert format_verbose(9_876.54321) == "9 μs 876.54 ns"
+    end
+
+    test ".format_verbose(98_765.4321)" do
+      assert format_verbose(98_765.4321) == "98 μs 765.43 ns"
+    end
+
+    test ".format_verbose(987_654.321)" do
+      assert format_verbose(987_654.321) == "987 μs 654.32 ns"
+    end
+
+    test ".format_verbose(9_008_000_000)" do
+      assert format_verbose(9_008_000_000) == "9 s 8 ms"
+    end
+
+    test ".format_verbose(9_876_543_210)" do
+      assert format_verbose(9_876_543_210) == "9 s 876 ms 543 μs 210 ns"
+    end
+
+    test ".format_verbose(90_000_000_000)" do
+      assert format_verbose(90_000_000_000) == "1 min 30 s"
+    end
+
+    test ".format_verbose(98_765_432_190)" do
+      assert format_verbose(98_765_432_190) == "1 min 38 s 765 ms 432 μs 190 ns"
+    end
+
+    test ".format_verbose(987_654_321_987.6)" do
+      assert format_verbose(987_654_321_987.6) == "16 min 27 s 654 ms 321 μs 987.60 ns"
+    end
+
+    test ".format_verbose(3_900_000_000_000)" do
+      assert format_verbose(3_900_000_000_000) == "1 h 5 min"
+    end
+
+    test ".format_verbose(9_876_543_219_876.5)" do
+      assert format_verbose(9_876_543_219_876.5) == "2 h 44 min 36 s 543 ms 219 μs 876.50 ns"
     end
   end
 

--- a/test/benchee/output/benchmark_printer_test.exs
+++ b/test/benchee/output/benchmark_printer_test.exs
@@ -72,7 +72,7 @@ defmodule Benchee.Output.BenchmarkPrintertest do
       assert output =~ "time: 1 min"
       assert output =~ "memory time: 5 s"
       assert output =~ "parallel: 1"
-      assert output =~ "Estimated total run time: 2.50 min"
+      assert output =~ "Estimated total run time: 2 min 30 s"
     end
 
     @inputs %{"Arg 1" => 1, "Arg 2" => 2}


### PR DESCRIPTION
As per issue https://github.com/bencheeorg/benchee/issues/332, it would be nice to format `Duration` in a more verbose fashion.

Another option would be to generalize the `place_values/1` function and put it into the `Scale` module (and extend extended the behaviour with `units/0` function returning all units for the implementor), and similarly implement `format_verbose/1` as part of the `Format` module. 
However, I'm not sure if it's so useful to have this functionality for `Count` and `Memory` modules too but I'd like to hear your opinions!