### PR TITLE
Extension: Fallback to otp_release when OTP_VERSION is unavailable

### DIFF
--- a/lib/benchee/system.ex
+++ b/lib/benchee/system.ex
@@ -37,7 +37,13 @@ defmodule Benchee.System do
       {:ok, version} ->
         String.trim(version)
 
-      {:error, _reason} ->
+      # Livebook seemingly doesn't have the file where we expect it to be:
+      # https://github.com/bencheeorg/benchee/issues/367
+      {:error, reason} ->
+        IO.puts(
+          "Error trying to determine erlang version #{reason}, falling back to overall OTP version"
+        )
+
         to_string(otp_release)
     end
   end

--- a/lib/benchee/utility/erlang_version.ex
+++ b/lib/benchee/utility/erlang_version.ex
@@ -72,6 +72,14 @@ defmodule Benchee.Utility.ErlangVersion do
       iex> Benchee.Utility.ErlangVersion.includes_fixes_from?("23.0-rc0", "22.0.0")
       true
 
+      # since we are falling back to general OTP versions now, test those as well
+      iex> Benchee.Utility.ErlangVersion.includes_fixes_from?("21", "22.0.0")
+      false
+      iex> Benchee.Utility.ErlangVersion.includes_fixes_from?("22", "22.0.0")
+      true
+      iex> Benchee.Utility.ErlangVersion.includes_fixes_from?("23.0", "22.0.0")
+      true
+
       # completely broken versions are assumed to be good to avoid false positives
       # as this is not a main functionality but code to potentially work around an older erlang
       # bug.
@@ -104,6 +112,7 @@ defmodule Benchee.Utility.ErlangVersion do
       case dot_count do
         3 -> Regex.replace(@last_version_segment, erlang_version, "")
         1 -> deal_with_major_minor(erlang_version)
+        0 -> "#{erlang_version}.0.0"
         _ -> erlang_version
       end
 


### PR DESCRIPTION
Follow up to https://github.com/bencheeorg/benchee/pull/368

Still fixes #367 

* still print an error
* fix actual versions comparisons