### PR TITLE
Import all the doctests!

### DIFF
--- a/lib/benchee/configuration.ex
+++ b/lib/benchee/configuration.ex
@@ -176,7 +176,7 @@ defmodule Benchee.Configuration do
 
   ## Examples
 
-      iex> Benchee.init
+      iex> init()
       %Benchee.Suite{
         configuration:
           %Benchee.Configuration{
@@ -204,7 +204,7 @@ defmodule Benchee.Configuration do
         scenarios: []
       }
 
-      iex> Benchee.init time: 1, warmup: 0.2
+      iex> init(time: 1, warmup: 0.2)
       %Benchee.Suite{
         configuration:
           %Benchee.Configuration{
@@ -232,7 +232,7 @@ defmodule Benchee.Configuration do
         scenarios: []
       }
 
-      iex> Benchee.init %{time: 1, warmup: 0.2}
+      iex> init(%{time: 1, warmup: 0.2})
       %Benchee.Suite{
         configuration:
           %Benchee.Configuration{
@@ -260,7 +260,7 @@ defmodule Benchee.Configuration do
         scenarios: []
       }
 
-      iex> Benchee.init(
+      iex> init(
       ...>   parallel: 2,
       ...>   time: 1,
       ...>   warmup: 0.2,

--- a/lib/benchee/conversion/count.ex
+++ b/lib/benchee/conversion/count.ex
@@ -49,13 +49,13 @@ defmodule Benchee.Conversion.Count do
 
   ## Examples
 
-      iex> {value, unit} = Benchee.Conversion.Count.scale(4_321.09)
+      iex> {value, unit} = scale(4_321.09)
       iex> value
       4.32109
       iex> unit.name
       :thousand
 
-      iex> {value, unit} = Benchee.Conversion.Count.scale(0.0045)
+      iex> {value, unit} = scale(0.0045)
       iex> value
       0.0045
       iex> unit.name
@@ -89,7 +89,7 @@ defmodule Benchee.Conversion.Count do
 
   ## Examples
 
-      iex> Benchee.Conversion.Count.unit_for :thousand
+      iex> unit_for :thousand
       %Benchee.Conversion.Unit{
         name:      :thousand,
         magnitude: 1_000,
@@ -97,7 +97,7 @@ defmodule Benchee.Conversion.Count do
         long:      "Thousand"
       }
 
-      iex> Benchee.Conversion.Count.unit_for(%Benchee.Conversion.Unit{
+      iex> unit_for(%Benchee.Conversion.Unit{
       ...>   name:      :thousand,
       ...>   magnitude: 1_000,
       ...>   label:     "K",
@@ -119,16 +119,16 @@ defmodule Benchee.Conversion.Count do
 
   ## Examples
 
-      iex> Benchee.Conversion.Count.scale(12345, :one)
+      iex> scale(12345, :one)
       12345.0
 
-      iex> Benchee.Conversion.Count.scale(12345, :thousand)
+      iex> scale(12345, :thousand)
       12.345
 
-      iex> Benchee.Conversion.Count.scale(12345, :billion)
+      iex> scale(12345, :billion)
       1.2345e-5
 
-      iex> Benchee.Conversion.Count.scale(12345, :million)
+      iex> scale(12345, :million)
       0.012345
 
   """
@@ -141,7 +141,7 @@ defmodule Benchee.Conversion.Count do
 
   ## Examples
 
-    iex> {value, unit} = Benchee.Conversion.Count.convert({2500, :thousand}, :million)
+    iex> {value, unit} = convert({2500, :thousand}, :million)
     iex> value
     2.5
     iex> unit.name
@@ -160,16 +160,16 @@ defmodule Benchee.Conversion.Count do
 
   ## Examples
 
-      iex> Benchee.Conversion.Count.best([23, 23_000, 34_000, 2_340_000]).name
+      iex> best([23, 23_000, 34_000, 2_340_000]).name
       :thousand
 
-      iex> Benchee.Conversion.Count.best([23, 23_000, 34_000, 2_340_000, 3_450_000]).name
+      iex> best([23, 23_000, 34_000, 2_340_000, 3_450_000]).name
       :million
 
-      iex> Benchee.Conversion.Count.best([23, 23_000, 34_000, 2_340_000], strategy: :smallest).name
+      iex> best([23, 23_000, 34_000, 2_340_000], strategy: :smallest).name
       :one
 
-      iex> Benchee.Conversion.Count.best([23, 23_000, 34_000, 2_340_000], strategy: :largest).name
+      iex> best([23, 23_000, 34_000, 2_340_000], strategy: :largest).name
       :million
 
   """
@@ -184,7 +184,7 @@ defmodule Benchee.Conversion.Count do
 
   ## Examples
 
-      iex> Benchee.Conversion.Count.base_unit.name
+      iex> base_unit().name
       :one
 
   """
@@ -196,16 +196,16 @@ defmodule Benchee.Conversion.Count do
 
   ## Examples
 
-      iex> Benchee.Conversion.Count.format(45_678.9)
+      iex> format(45_678.9)
       "45.68 K"
 
-      iex> Benchee.Conversion.Count.format(45.6789)
+      iex> format(45.6789)
       "45.68"
 
-      iex> Benchee.Conversion.Count.format({45.6789, :thousand})
+      iex> format({45.6789, :thousand})
       "45.68 K"
 
-      iex> Benchee.Conversion.Count.format({45.6789, %Benchee.Conversion.Unit{long: "Thousand", magnitude: "1_000", label: "K"}})
+      iex> format({45.6789, %Benchee.Conversion.Unit{long: "Thousand", magnitude: "1_000", label: "K"}})
       "45.68 K"
   """
   def format(count) do

--- a/lib/benchee/conversion/deviation_percent.ex
+++ b/lib/benchee/conversion/deviation_percent.ex
@@ -17,10 +17,10 @@ defmodule Benchee.Conversion.DeviationPercent do
 
   ## Examples
 
-      iex> Benchee.Conversion.DeviationPercent.format(0.12345)
+      iex> format(0.12345)
       "±12.35%"
 
-      iex> Benchee.Conversion.DeviationPercent.format(1)
+      iex> format(1)
       "±100.00%"
   """
   def format(std_dev_ratio) do

--- a/lib/benchee/conversion/duration.ex
+++ b/lib/benchee/conversion/duration.ex
@@ -65,19 +65,19 @@ defmodule Benchee.Conversion.Duration do
 
   ## Examples
 
-      iex> {value, unit} = Benchee.Conversion.Duration.scale(1)
+      iex> {value, unit} = scale(1)
       iex> value
       1.0
       iex> unit.name
       :nanosecond
 
-      iex> {value, unit} = Benchee.Conversion.Duration.scale(1_234)
+      iex> {value, unit} = scale(1_234)
       iex> value
       1.234
       iex> unit.name
       :microsecond
 
-      iex> {value, unit} = Benchee.Conversion.Duration.scale(11_234_567_890_123)
+      iex> {value, unit} = scale(11_234_567_890_123)
       iex> value
       3.1207133028119443
       iex> unit.name
@@ -118,7 +118,7 @@ defmodule Benchee.Conversion.Duration do
 
   ## Examples
 
-      iex> Benchee.Conversion.Duration.unit_for :hour
+      iex> unit_for :hour
       %Benchee.Conversion.Unit{
         name:      :hour,
         magnitude: 3_600_000_000_000,
@@ -126,7 +126,7 @@ defmodule Benchee.Conversion.Duration do
         long:      "Hours"
       }
 
-      iex> Benchee.Conversion.Duration.unit_for(%Benchee.Conversion.Unit{
+      iex> unit_for(%Benchee.Conversion.Unit{
       ...>   name:      :hour,
       ...>   magnitude: 3_600_000_000_000,
       ...>   label:     "h",
@@ -148,13 +148,13 @@ defmodule Benchee.Conversion.Duration do
 
   ## Examples
 
-      iex> Benchee.Conversion.Duration.scale(12345, :nanosecond)
+      iex> scale(12345, :nanosecond)
       12345.0
 
-      iex> Benchee.Conversion.Duration.scale(12345, :microsecond)
+      iex> scale(12345, :microsecond)
       12.345
 
-      iex> Benchee.Conversion.Duration.scale(12345, :minute)
+      iex> scale(12345, :minute)
       2.0575e-7
 
   """
@@ -167,7 +167,7 @@ defmodule Benchee.Conversion.Duration do
 
   ## Examples
 
-    iex> {value, unit} = Benchee.Conversion.Duration.convert({90, :minute}, :hour)
+    iex> {value, unit} = convert({90, :minute}, :hour)
     iex> value
     1.5
     iex> unit.name
@@ -182,14 +182,14 @@ defmodule Benchee.Conversion.Duration do
 
   ## Examples
 
-      iex> Benchee.Conversion.Duration.convert_value({1.234, :second}, :microsecond)
+      iex> convert_value({1.234, :second}, :microsecond)
       1_234_000.0
 
-      iex> Benchee.Conversion.Duration.convert_value({1.234, :minute}, :microsecond)
+      iex> convert_value({1.234, :minute}, :microsecond)
       7.404e7
 
-      iex> microseconds = Benchee.Conversion.Duration.convert_value({1.234, :minute}, :microsecond)
-      iex> {value, _} = Benchee.Conversion.Duration.convert({microseconds, :microsecond}, :minute)
+      iex> microseconds = convert_value({1.234, :minute}, :microsecond)
+      iex> {value, _} = convert({microseconds, :microsecond}, :minute)
       iex> value
       1.234
 
@@ -208,16 +208,16 @@ defmodule Benchee.Conversion.Duration do
 
   ## Examples
 
-      iex> Benchee.Conversion.Duration.best([23, 23_000, 34_000, 2_340_000]).name
+      iex> best([23, 23_000, 34_000, 2_340_000]).name
       :microsecond
 
-      iex> Benchee.Conversion.Duration.best([23, 23_000, 34_000_000, 2_340_000_000, 3_450_000_000]).name
+      iex> best([23, 23_000, 34_000_000, 2_340_000_000, 3_450_000_000]).name
       :second
 
-      iex> Benchee.Conversion.Duration.best([23, 23_000, 34_000, 2_340_000], strategy: :smallest).name
+      iex> best([23, 23_000, 34_000, 2_340_000], strategy: :smallest).name
       :nanosecond
 
-      iex> Benchee.Conversion.Duration.best([23, 23_000, 34_000, 2_340_000_000], strategy: :largest).name
+      iex> best([23, 23_000, 34_000, 2_340_000_000], strategy: :largest).name
       :second
   """
   def best(list, opts \\ [strategy: :best])
@@ -231,7 +231,7 @@ defmodule Benchee.Conversion.Duration do
 
   ## Examples
 
-      iex> Benchee.Conversion.Duration.base_unit.name
+      iex> base_unit().name
       :nanosecond
 
   """
@@ -243,16 +243,16 @@ defmodule Benchee.Conversion.Duration do
 
   ## Examples
 
-      iex> Benchee.Conversion.Duration.format(45_678.9)
+      iex> format(45_678.9)
       "45.68 μs"
 
-      iex> Benchee.Conversion.Duration.format(45.6789)
+      iex> format(45.6789)
       "45.68 ns"
 
-      iex> Benchee.Conversion.Duration.format({45.6789, :millisecond})
+      iex> format({45.6789, :millisecond})
       "45.68 ms"
 
-      iex> Benchee.Conversion.Duration.format {45.6789,
+      iex> format {45.6789,
       ...>   %Benchee.Conversion.Unit{
       ...>     long: "Milliseconds", magnitude: 1000, label: "ms"}
       ...>   }

--- a/lib/benchee/conversion/format.ex
+++ b/lib/benchee/conversion/format.ex
@@ -41,7 +41,7 @@ defmodule Benchee.Conversion.Format do
   formatted output. If no `separator/0` function exists, the default separator
   (a single space) will be used.
 
-      iex> Benchee.Conversion.Format.format({1.0, :kilobyte}, Benchee.Conversion.Memory)
+      iex> format({1.0, :kilobyte}, Benchee.Conversion.Memory)
       "1 KB"
 
   """

--- a/lib/benchee/conversion/memory.ex
+++ b/lib/benchee/conversion/memory.ex
@@ -56,14 +56,14 @@ defmodule Benchee.Conversion.Memory do
 
   ## Examples
 
-    iex> {value, unit} = Benchee.Conversion.Memory.convert({1024, :kilobyte}, :megabyte)
+    iex> {value, unit} = convert({1024, :kilobyte}, :megabyte)
     iex> value
     1.0
     iex> unit.name
     :megabyte
 
-    iex> current_unit = Benchee.Conversion.Memory.unit_for :kilobyte
-    iex> {value, unit} = Benchee.Conversion.Memory.convert({1024, current_unit}, :megabyte)
+    iex> current_unit = unit_for :kilobyte
+    iex> {value, unit} = convert({1024, current_unit}, :megabyte)
     iex> value
     1.0
     iex> unit.name
@@ -81,25 +81,25 @@ defmodule Benchee.Conversion.Memory do
 
   ## Examples
 
-    iex> {value, unit} = Benchee.Conversion.Memory.scale(1)
+    iex> {value, unit} = scale(1)
     iex> value
     1.0
     iex> unit.name
     :byte
 
-    iex> {value, unit} = Benchee.Conversion.Memory.scale(1_234)
+    iex> {value, unit} = scale(1_234)
     iex> value
     1.205078125
     iex> unit.name
     :kilobyte
 
-    iex> {value, unit} = Benchee.Conversion.Memory.scale(11_234_567_890.123)
+    iex> {value, unit} = scale(11_234_567_890.123)
     iex> value
     10.463006692121736
     iex> unit.name
     :gigabyte
 
-    iex> {value, unit} = Benchee.Conversion.Memory.scale(1_111_234_567_890.123)
+    iex> {value, unit} = scale(1_111_234_567_890.123)
     iex> value
     1.0106619519229962
     iex> unit.name
@@ -140,7 +140,7 @@ defmodule Benchee.Conversion.Memory do
 
   ## Examples
 
-      iex> Benchee.Conversion.Memory.unit_for :gigabyte
+      iex> unit_for :gigabyte
       %Benchee.Conversion.Unit{
           name:      :gigabyte,
           magnitude: 1_073_741_824,
@@ -148,7 +148,7 @@ defmodule Benchee.Conversion.Memory do
           long:      "Gigabytes"
       }
 
-      iex> Benchee.Conversion.Memory.unit_for(%Benchee.Conversion.Unit{
+      iex> unit_for(%Benchee.Conversion.Unit{
       ...>   name:      :gigabyte,
       ...>   magnitude: 1_073_741_824,
       ...>   label:     "GB",
@@ -170,13 +170,13 @@ defmodule Benchee.Conversion.Memory do
 
   ## Examples
 
-      iex> Benchee.Conversion.Memory.scale(12345, :kilobyte)
+      iex> scale(12345, :kilobyte)
       12.0556640625
 
-      iex> Benchee.Conversion.Memory.scale(12345, :megabyte)
+      iex> scale(12345, :megabyte)
       0.011773109436035156
 
-      iex> Benchee.Conversion.Memory.scale(123_456_789, :gigabyte)
+      iex> scale(123_456_789, :gigabyte)
       0.11497809458523989
 
   """
@@ -195,16 +195,16 @@ defmodule Benchee.Conversion.Memory do
 
   ## Examples
 
-      iex> Benchee.Conversion.Memory.best([23, 23_000, 34_000, 2_340_000]).name
+      iex> best([23, 23_000, 34_000, 2_340_000]).name
       :kilobyte
 
-      iex> Benchee.Conversion.Memory.best([23, 23_000, 34_000, 2_340_000, 3_450_000]).name
+      iex> best([23, 23_000, 34_000, 2_340_000, 3_450_000]).name
       :megabyte
 
-      iex> Benchee.Conversion.Memory.best([23, 23_000, 34_000, 2_340_000], strategy: :smallest).name
+      iex> best([23, 23_000, 34_000, 2_340_000], strategy: :smallest).name
       :byte
 
-      iex> Benchee.Conversion.Memory.best([23, 23_000, 34_000, 2_340_000], strategy: :largest).name
+      iex> best([23, 23_000, 34_000, 2_340_000], strategy: :largest).name
       :megabyte
   """
   def best(list, opts \\ [strategy: :best])
@@ -218,7 +218,7 @@ defmodule Benchee.Conversion.Memory do
 
   ## Examples
 
-      iex> Benchee.Conversion.Memory.base_unit.name
+      iex> base_unit().name
       :byte
 
   """
@@ -230,16 +230,16 @@ defmodule Benchee.Conversion.Memory do
 
   ## Examples
 
-      iex> Benchee.Conversion.Memory.format(45_678.9)
+      iex> format(45_678.9)
       "44.61 KB"
 
-      iex> Benchee.Conversion.Memory.format(45.6789)
+      iex> format(45.6789)
       "45.68 B"
 
-      iex> Benchee.Conversion.Memory.format({45.6789, :kilobyte})
+      iex> format({45.6789, :kilobyte})
       "45.68 KB"
 
-      iex> Benchee.Conversion.Memory.format {45.6789,
+      iex> format {45.6789,
       ...>   %Benchee.Conversion.Unit{
       ...>     long: "Kilobytes", magnitude: 1024, label: "KB"}
       ...>   }

--- a/lib/benchee/conversion/scale.ex
+++ b/lib/benchee/conversion/scale.ex
@@ -61,7 +61,7 @@ defmodule Benchee.Conversion.Scale do
 
   ## Examples
 
-      iex> Benchee.Conversion.Scale.scale(12345, :thousand, Benchee.Conversion.Count)
+      iex> scale(12345, :thousand, Benchee.Conversion.Count)
       12.345
   """
   def scale(value, unit = %Unit{}, _module) do
@@ -78,7 +78,7 @@ defmodule Benchee.Conversion.Scale do
   ## Examples
 
       iex> unit = %Benchee.Conversion.Unit{magnitude: 1000}
-      iex> Benchee.Conversion.Scale.scale 12345, unit
+      iex> scale 12345, unit
       12.345
   """
   def scale(value, %Unit{magnitude: magnitude}) do
@@ -130,31 +130,31 @@ defmodule Benchee.Conversion.Scale do
   ## Examples
 
       iex> list = [1, 101, 1_001, 10_001, 100_001, 1_000_001]
-      iex> Benchee.Conversion.Scale.best_unit(list, Benchee.Conversion.Count, strategy: :best).name
+      iex> best_unit(list, Benchee.Conversion.Count, strategy: :best).name
       :thousand
 
       iex> list = [1, 101, 1_001, 10_001, 100_001, 1_000_001]
-      iex> Benchee.Conversion.Scale.best_unit(list, Benchee.Conversion.Count, strategy: :smallest).name
+      iex> best_unit(list, Benchee.Conversion.Count, strategy: :smallest).name
       :one
 
       iex> list = [1, 101, 1_001, 10_001, 100_001, 1_000_001]
-      iex> Benchee.Conversion.Scale.best_unit(list, Benchee.Conversion.Count, strategy: :largest).name
+      iex> best_unit(list, Benchee.Conversion.Count, strategy: :largest).name
       :million
 
       iex> list = []
-      iex> Benchee.Conversion.Scale.best_unit(list, Benchee.Conversion.Count, strategy: :best).name
+      iex> best_unit(list, Benchee.Conversion.Count, strategy: :best).name
       :one
 
       iex> list = [nil]
-      iex> Benchee.Conversion.Scale.best_unit(list, Benchee.Conversion.Count, strategy: :best).name
+      iex> best_unit(list, Benchee.Conversion.Count, strategy: :best).name
       :one
 
       iex> list = [nil, nil, nil, nil]
-      iex> Benchee.Conversion.Scale.best_unit(list, Benchee.Conversion.Count, strategy: :best).name
+      iex> best_unit(list, Benchee.Conversion.Count, strategy: :best).name
       :one
 
       iex> list = [nil, nil, nil, nil, 2_000]
-      iex> Benchee.Conversion.Scale.best_unit(list, Benchee.Conversion.Count, strategy: :best).name
+      iex> best_unit(list, Benchee.Conversion.Count, strategy: :best).name
       :thousand
   """
   def best_unit(measurements, module, options) do

--- a/lib/benchee/formatters/console.ex
+++ b/lib/benchee/formatters/console.ex
@@ -80,7 +80,7 @@ defmodule Benchee.Formatters.Console do
   ...>     unit_scaling: :best,
   ...>   }
   ...> }
-  iex> Benchee.Formatters.Console.format(suite, %{comparison: false, extended_statistics: false})
+  iex> format(suite, %{comparison: false, extended_statistics: false})
   [["\n##### With input My input #####", "\nName             ips        average  deviation         median         99th %\n",
   "My Job           5 K         200 ns    ±10.00%         190 ns      300.10 ns\n",
   "Job 2         2.50 K         400 ns    ±20.00%         390 ns      500.10 ns\n"]]

--- a/lib/benchee/formatters/console/run_time.ex
+++ b/lib/benchee/formatters/console/run_time.ex
@@ -58,7 +58,7 @@ defmodule Benchee.Formatters.Console.RunTime do
   ...>   }
   ...> ]
   iex> configuration = %{comparison: false, unit_scaling: :best, extended_statistics: true}
-  iex> Benchee.Formatters.Console.RunTime.format_scenarios(scenarios, configuration)
+  iex> format_scenarios(scenarios, configuration)
   ["\nName             ips        average  deviation         median         99th %\n",
   "My Job           5 K         200 ns    ±10.00%         190 ns      300.10 ns\n",
   "Job 2         2.50 K         400 ns    ±20.00%         390 ns      500.10 ns\n",

--- a/lib/benchee/scenario.ex
+++ b/lib/benchee/scenario.ex
@@ -80,12 +80,13 @@ defmodule Benchee.Scenario do
 
   ## Examples
 
-      iex> alias Benchee.Scenario
-      iex> Scenario.display_name(%Scenario{job_name: "flat_map"})
+      iex> display_name(%Benchee.Scenario{job_name: "flat_map"})
       "flat_map"
-      iex> Scenario.display_name(%Scenario{job_name: "flat_map", tag: "main"})
+
+      iex> display_name(%Benchee.Scenario{job_name: "flat_map", tag: "main"})
       "flat_map (main)"
-      iex> Scenario.display_name(%{job_name: "flat_map"})
+
+      iex> display_name(%{job_name: "flat_map"})
       "flat_map"
   """
   @spec display_name(t) :: String.t()
@@ -104,16 +105,16 @@ defmodule Benchee.Scenario do
 
   ## Examples
 
-      iex> alias Benchee.Scenario
-      iex> alias Benchee.Statistics
-      iex> scenario = %Scenario{run_time_data: %Benchee.CollectionData{statistics: %Statistics{sample_size: 100}}}
-      iex> Scenario.data_processed?(scenario, :run_time)
+      iex> scenario = %Benchee.Scenario{run_time_data: %Benchee.CollectionData{statistics: %Benchee.Statistics{sample_size: 100}}}
+      iex> data_processed?(scenario, :run_time)
       true
-      iex> scenario = %Scenario{memory_usage_data: %Benchee.CollectionData{statistics: %Statistics{sample_size: 1}}}
-      iex> Scenario.data_processed?(scenario, :memory)
+
+      iex> scenario = %Benchee.Scenario{memory_usage_data: %Benchee.CollectionData{statistics: %Benchee.Statistics{sample_size: 1}}}
+      iex> data_processed?(scenario, :memory)
       true
-      iex> scenario = %Scenario{memory_usage_data: %Benchee.CollectionData{statistics: %Statistics{sample_size: 0}}}
-      iex> Scenario.data_processed?(scenario, :memory)
+
+      iex> scenario = %Benchee.Scenario{memory_usage_data: %Benchee.CollectionData{statistics: %Benchee.Statistics{sample_size: 0}}}
+      iex> data_processed?(scenario, :memory)
       false
   """
   @spec data_processed?(t, :run_time | :memory) :: boolean

--- a/lib/benchee/statistics.ex
+++ b/lib/benchee/statistics.ex
@@ -115,7 +115,7 @@ defmodule Benchee.Statistics do
       ...>   }
       ...> ]
       iex> suite = %Benchee.Suite{scenarios: scenarios}
-      iex> Benchee.Statistics.statistics(suite)
+      iex> statistics(suite)
       %Benchee.Suite{
         scenarios: [
           %Benchee.Scenario{

--- a/lib/benchee/utility/deep_convert.ex
+++ b/lib/benchee/utility/deep_convert.ex
@@ -6,25 +6,25 @@ defmodule Benchee.Utility.DeepConvert do
 
   ## Examples
 
-  iex> Benchee.Utility.DeepConvert.to_map([a: 1, b: 2])
+  iex> to_map([a: 1, b: 2])
   %{a: 1, b: 2}
 
-  iex> Benchee.Utility.DeepConvert.to_map([a: [b: 2], c: [d: 3, e: 4, e: 5]])
+  iex> to_map([a: [b: 2], c: [d: 3, e: 4, e: 5]])
   %{a: %{b: 2}, c: %{d: 3, e: 5}}
 
-  iex> Benchee.Utility.DeepConvert.to_map([a: [b: 2], c: [1, 2, 3], d: []])
+  iex> to_map([a: [b: 2], c: [1, 2, 3], d: []])
   %{a: %{b: 2}, c: [1, 2, 3], d: []}
 
-  iex> Benchee.Utility.DeepConvert.to_map(%{a: %{b: 2}, c: %{d: 3, e: 5}})
+  iex> to_map(%{a: %{b: 2}, c: %{d: 3, e: 5}})
   %{a: %{b: 2}, c: %{d: 3, e: 5}}
 
-  iex> Benchee.Utility.DeepConvert.to_map([])
+  iex> to_map([])
   %{}
 
-  iex> Benchee.Utility.DeepConvert.to_map([a: [b: [f: 5]]], [:a])
+  iex> to_map([a: [b: [f: 5]]], [:a])
   %{a: [b: [f: 5]]}
 
-  iex> Benchee.Utility.DeepConvert.to_map([a: [b: [f: 5]], c: [d: 3]], [:b])
+  iex> to_map([a: [b: [f: 5]], c: [d: 3]], [:b])
   %{a: %{b: [f: 5]}, c: %{d: 3}}
   """
   def to_map(structure, exclusions \\ [])

--- a/lib/benchee/utility/erlang_version.ex
+++ b/lib/benchee/utility/erlang_version.ex
@@ -16,76 +16,76 @@ defmodule Benchee.Utility.ErlangVersion do
 
   ## Examples
 
-      iex> Benchee.Utility.ErlangVersion.includes_fixes_from?("22.0.0", "22.0.0")
+      iex> includes_fixes_from?("22.0.0", "22.0.0")
       true
 
-      iex> Benchee.Utility.ErlangVersion.includes_fixes_from?("22.0.1", "22.0.0")
+      iex> includes_fixes_from?("22.0.1", "22.0.0")
       true
 
-      iex> Benchee.Utility.ErlangVersion.includes_fixes_from?("22.0.0", "22.0.1")
+      iex> includes_fixes_from?("22.0.0", "22.0.1")
       false
 
-      iex> Benchee.Utility.ErlangVersion.includes_fixes_from?("22.0.4", "22.0.5")
+      iex> includes_fixes_from?("22.0.4", "22.0.5")
       false
 
-      iex> Benchee.Utility.ErlangVersion.includes_fixes_from?("22.0.4", "22.0.4")
+      iex> includes_fixes_from?("22.0.4", "22.0.4")
       true
 
-      iex> Benchee.Utility.ErlangVersion.includes_fixes_from?("22.0.5", "22.0.4")
+      iex> includes_fixes_from?("22.0.5", "22.0.4")
       true
 
-      iex> Benchee.Utility.ErlangVersion.includes_fixes_from?("21.999.9999", "22.0.0")
+      iex> includes_fixes_from?("21.999.9999", "22.0.0")
       false
 
-      iex> Benchee.Utility.ErlangVersion.includes_fixes_from?("23.0.0", "22.0.0")
+      iex> includes_fixes_from?("23.0.0", "22.0.0")
       true
 
       # weird longer version numbers work
-      iex> Benchee.Utility.ErlangVersion.includes_fixes_from?("22.0.0.0", "22.0.0")
+      iex> includes_fixes_from?("22.0.0.0", "22.0.0")
       true
 
-      iex> Benchee.Utility.ErlangVersion.includes_fixes_from?("22.0.0.14", "22.0.0")
+      iex> includes_fixes_from?("22.0.0.14", "22.0.0")
       true
 
-      iex> Benchee.Utility.ErlangVersion.includes_fixes_from?("23.3.5.14", "22.0.0")
+      iex> includes_fixes_from?("23.3.5.14", "22.0.0")
       true
 
-      iex> Benchee.Utility.ErlangVersion.includes_fixes_from?("21.3.5.14", "22.0.0")
+      iex> includes_fixes_from?("21.3.5.14", "22.0.0")
       false
 
       # weird shorter version numbers work
-      iex> Benchee.Utility.ErlangVersion.includes_fixes_from?("22.0", "22.0.0")
+      iex> includes_fixes_from?("22.0", "22.0.0")
       true
 
-      iex> Benchee.Utility.ErlangVersion.includes_fixes_from?("22.0", "22.0.1")
+      iex> includes_fixes_from?("22.0", "22.0.1")
       false
 
-      iex> Benchee.Utility.ErlangVersion.includes_fixes_from?("22.1", "22.0.0")
+      iex> includes_fixes_from?("22.1", "22.0.0")
       true
 
-      iex> Benchee.Utility.ErlangVersion.includes_fixes_from?("21.3", "22.0.0")
+      iex> includes_fixes_from?("21.3", "22.0.0")
       false
 
       # rc version numbers work
-      iex> Benchee.Utility.ErlangVersion.includes_fixes_from?("22.0-rc3", "22.0.0")
+      iex> includes_fixes_from?("22.0-rc3", "22.0.0")
       false
-      iex> Benchee.Utility.ErlangVersion.includes_fixes_from?("23.0-rc0", "22.0.0")
+      iex> includes_fixes_from?("23.0-rc0", "22.0.0")
       true
 
       # since we are falling back to general OTP versions now, test those as well
-      iex> Benchee.Utility.ErlangVersion.includes_fixes_from?("21", "22.0.0")
+      iex> includes_fixes_from?("21", "22.0.0")
       false
-      iex> Benchee.Utility.ErlangVersion.includes_fixes_from?("22", "22.0.0")
+      iex> includes_fixes_from?("22", "22.0.0")
       true
-      iex> Benchee.Utility.ErlangVersion.includes_fixes_from?("23.0", "22.0.0")
+      iex> includes_fixes_from?("23.0", "22.0.0")
       true
 
       # completely broken versions are assumed to be good to avoid false positives
       # as this is not a main functionality but code to potentially work around an older erlang
       # bug.
-      iex> Benchee.Utility.ErlangVersion.includes_fixes_from?("super erlang", "22.0.0")
+      iex> includes_fixes_from?("super erlang", "22.0.0")
       true
-      iex> Benchee.Utility.ErlangVersion.includes_fixes_from?("", "22.0.0")
+      iex> includes_fixes_from?("", "22.0.0")
       true
   """
   def includes_fixes_from?(version_to_check, reference_version) do

--- a/lib/benchee/utility/file_creation.ex
+++ b/lib/benchee/utility/file_creation.ex
@@ -65,46 +65,46 @@ defmodule Benchee.Utility.FileCreation do
 
   ## Examples
 
-      iex> Benchee.Utility.FileCreation.interleave("abc.csv", "hello")
+      iex> interleave("abc.csv", "hello")
       "abc_hello.csv"
 
-      iex> Benchee.Utility.FileCreation.interleave("abc.csv", "Big Input")
+      iex> interleave("abc.csv", "Big Input")
       "abc_big_input.csv"
 
-      iex> Benchee.Utility.FileCreation.interleave("abc.csv", "String.length/1")
+      iex> interleave("abc.csv", "String.length/1")
       "abc_string_length_1.csv"
 
-      iex> Benchee.Utility.FileCreation.interleave("bench/abc.csv", "Big Input")
+      iex> interleave("bench/abc.csv", "Big Input")
       "bench/abc_big_input.csv"
 
-      iex> Benchee.Utility.FileCreation.interleave("bench/abc.csv",
+      iex> interleave("bench/abc.csv",
       ...>   ["Big Input"])
       "bench/abc_big_input.csv"
 
-      iex> Benchee.Utility.FileCreation.interleave("abc.csv", [])
+      iex> interleave("abc.csv", [])
       "abc.csv"
 
-      iex> Benchee.Utility.FileCreation.interleave("bench/abc.csv",
+      iex> interleave("bench/abc.csv",
       ...>   ["Big Input", "Comparison"])
       "bench/abc_big_input_comparison.csv"
 
-      iex> Benchee.Utility.FileCreation.interleave("bench/A B C.csv",
+      iex> interleave("bench/A B C.csv",
       ...>   ["Big Input", "Comparison"])
       "bench/A B C_big_input_comparison.csv"
 
-      iex> Benchee.Utility.FileCreation.interleave("bench/abc.csv",
+      iex> interleave("bench/abc.csv",
       ...>   ["Big Input", "Comparison", "great Stuff"])
       "bench/abc_big_input_comparison_great_stuff.csv"
 
       iex> marker = Benchee.Benchmark.no_input
-      iex> Benchee.Utility.FileCreation.interleave("abc.csv", marker)
+      iex> interleave("abc.csv", marker)
       "abc.csv"
-      iex> Benchee.Utility.FileCreation.interleave("abc.csv", [marker])
+      iex> interleave("abc.csv", [marker])
       "abc.csv"
-      iex> Benchee.Utility.FileCreation.interleave("abc.csv",
+      iex> interleave("abc.csv",
       ...>   [marker, "Comparison"])
       "abc_comparison.csv"
-      iex> Benchee.Utility.FileCreation.interleave("abc.csv",
+      iex> interleave("abc.csv",
       ...>   ["Something cool", marker, "Comparison"])
       "abc_something_cool_comparison.csv"
   """

--- a/test/benchee/benchmark/scenario_test.exs
+++ b/test/benchee/benchmark/scenario_test.exs
@@ -1,4 +1,4 @@
 defmodule Benchee.ScenarioTest do
   use ExUnit.Case, async: true
-  doctest Benchee.Scenario
+  doctest Benchee.Scenario, import: true
 end

--- a/test/benchee/configuration_test.exs
+++ b/test/benchee/configuration_test.exs
@@ -1,6 +1,6 @@
 defmodule Benchee.ConfigurationTest do
   use ExUnit.Case, async: true
-  doctest Benchee.Configuration
+  doctest Benchee.Configuration, import: true
 
   alias Benchee.{Configuration, Suite}
 

--- a/test/benchee/conversion/count_test.exs
+++ b/test/benchee/conversion/count_test.exs
@@ -1,7 +1,7 @@
 defmodule Benchee.Conversion.CountTest do
   use ExUnit.Case, async: true
   import Benchee.Conversion.Count
-  doctest Benchee.Conversion.Count
+  doctest Benchee.Conversion.Count, import: true
 
   describe ".scale" do
     test "123_456_789_012 scales to :billion" do

--- a/test/benchee/conversion/deviation_percent_test.exs
+++ b/test/benchee/conversion/deviation_percent_test.exs
@@ -1,4 +1,4 @@
 defmodule Benchee.Conversion.DeviationPercentTest do
   use ExUnit.Case, async: true
-  doctest Benchee.Conversion.DeviationPercent
+  doctest Benchee.Conversion.DeviationPercent, import: true
 end

--- a/test/benchee/conversion/duration_test.exs
+++ b/test/benchee/conversion/duration_test.exs
@@ -1,7 +1,7 @@
 defmodule Benchee.Conversion.DurationTest do
   use ExUnit.Case, async: true
   import Benchee.Conversion.Duration
-  doctest Benchee.Conversion.Duration
+  doctest Benchee.Conversion.Duration, import: true
 
   describe ".format" do
     test ".format(98.7654321)" do

--- a/test/benchee/conversion/format_test.exs
+++ b/test/benchee/conversion/format_test.exs
@@ -1,4 +1,4 @@
 defmodule Benchee.Conversion.FormatTest do
   use ExUnit.Case, async: true
-  doctest Benchee.Conversion.Format
+  doctest Benchee.Conversion.Format, import: true
 end

--- a/test/benchee/conversion/memory_test.exs
+++ b/test/benchee/conversion/memory_test.exs
@@ -1,7 +1,7 @@
 defmodule Benchee.Conversion.MemoryTest do
   use ExUnit.Case, async: true
   import Benchee.Conversion.Memory
-  doctest Benchee.Conversion.Memory
+  doctest Benchee.Conversion.Memory, import: true
 
   describe ".format" do
     test ".format(1_023)" do

--- a/test/benchee/conversion/scale_test.exs
+++ b/test/benchee/conversion/scale_test.exs
@@ -1,4 +1,4 @@
 defmodule Benchee.Conversion.ScaleTest do
   use ExUnit.Case, async: true
-  doctest Benchee.Conversion.Scale
+  doctest Benchee.Conversion.Scale, import: true
 end

--- a/test/benchee/conversion_test.exs
+++ b/test/benchee/conversion_test.exs
@@ -1,4 +1,4 @@
 defmodule Benchee.ConversionTest do
   use ExUnit.Case, async: true
-  doctest Benchee.Conversion
+  doctest Benchee.Conversion, import: true
 end

--- a/test/benchee/formatters/console/memory_test.exs
+++ b/test/benchee/formatters/console/memory_test.exs
@@ -1,6 +1,5 @@
 defmodule Benchee.Formatters.Console.MemoryTest do
   use ExUnit.Case, async: true
-  doctest Benchee.Formatters.Console.Memory
 
   alias Benchee.{CollectionData, Formatters.Console.Memory, Scenario, Statistics}
 

--- a/test/benchee/formatters/console/reductions_test.exs
+++ b/test/benchee/formatters/console/reductions_test.exs
@@ -1,6 +1,5 @@
 defmodule Benchee.Formatters.Console.ReductionsTest do
   use ExUnit.Case, async: true
-  doctest Benchee.Formatters.Console.Reductions
 
   alias Benchee.{CollectionData, Formatters.Console.Reductions, Scenario, Statistics}
 

--- a/test/benchee/formatters/console/run_time_test.exs
+++ b/test/benchee/formatters/console/run_time_test.exs
@@ -1,6 +1,6 @@
 defmodule Benchee.Formatters.Console.RunTimeTest do
   use ExUnit.Case, async: true
-  doctest Benchee.Formatters.Console.RunTime
+  doctest Benchee.Formatters.Console.RunTime, import: true
 
   alias Benchee.{CollectionData, Formatters.Console.RunTime, Scenario, Statistics}
 

--- a/test/benchee/formatters/console_test.exs
+++ b/test/benchee/formatters/console_test.exs
@@ -1,6 +1,6 @@
 defmodule Benchee.Formatters.ConsoleTest do
   use ExUnit.Case, async: true
-  doctest Benchee.Formatters.Console
+  doctest Benchee.Formatters.Console, import: true
 
   import ExUnit.CaptureIO
 

--- a/test/benchee/statistics_test.exs
+++ b/test/benchee/statistics_test.exs
@@ -1,7 +1,7 @@
 defmodule Benchee.StatistcsTest do
   use ExUnit.Case, async: true
   alias Benchee.{CollectionData, Configuration, Scenario, Statistics, Suite}
-  doctest Benchee.Statistics
+  doctest Benchee.Statistics, import: true
 
   @sample_1 [600, 470, 170, 430, 300]
   @sample_2 [17, 15, 23, 7, 9, 13]

--- a/test/benchee/utility/deep_convert_test.exs
+++ b/test/benchee/utility/deep_convert_test.exs
@@ -1,4 +1,4 @@
 defmodule Benchee.Utility.DeepConvertTest do
   use ExUnit.Case, async: true
-  doctest Benchee.Utility.DeepConvert
+  doctest Benchee.Utility.DeepConvert, import: true
 end

--- a/test/benchee/utility/erlang_version_test.exs
+++ b/test/benchee/utility/erlang_version_test.exs
@@ -1,5 +1,5 @@
 defmodule Benchee.Utility.ErlangVersionTest do
   use ExUnit.Case, async: true
 
-  doctest Benchee.Utility.ErlangVersion
+  doctest Benchee.Utility.ErlangVersion, import: true
 end

--- a/test/benchee/utility/file_creation_test.exs
+++ b/test/benchee/utility/file_creation_test.exs
@@ -1,4 +1,4 @@
 defmodule Benchee.Utility.FileCreationTest do
   use ExUnit.Case, async: true
-  doctest Benchee.Utility.FileCreation
+  doctest Benchee.Utility.FileCreation, import: true
 end

--- a/test/benchee_test.exs
+++ b/test/benchee_test.exs
@@ -15,8 +15,6 @@ defmodule BencheeTest do
   import ExUnit.CaptureIO
   import Benchee.TestHelpers
 
-  doctest Benchee
-
   @header_regex ~r/^Name.+ips.+average.+deviation.+median.+99th %$/m
   @test_configuration [time: 0.01, warmup: 0.005]
 


### PR DESCRIPTION
Such cleaner! Much joy!

Also, remove `doctest` calls where there are no actual doctests to be found/executed. Might be worth adding a warning to ExUnit?