### PR TITLE
chore(Elixir): fix compiler warnings for elixir 1.16

### DIFF
--- a/lib/benchee/benchmark/runner.ex
+++ b/lib/benchee/benchmark/runner.ex
@@ -168,7 +168,7 @@ defmodule Benchee.Benchmark.Runner do
     Enum.map(reductions, &(&1 - offset))
   end
 
-  defp run_reductions_benchmark(_, %ScenarioContext{config: %{reduction_time: 0.0}}) do
+  defp run_reductions_benchmark(_, %ScenarioContext{config: %{reduction_time: +0.0}}) do
     []
   end
 
@@ -191,7 +191,7 @@ defmodule Benchee.Benchmark.Runner do
     do_benchmark(scenario, new_context, Collect.Reductions, [])
   end
 
-  defp run_memory_benchmark(_, %ScenarioContext{config: %{memory_time: 0.0}}) do
+  defp run_memory_benchmark(_, %ScenarioContext{config: %{memory_time: +0.0}}) do
     []
   end
 
@@ -216,7 +216,7 @@ defmodule Benchee.Benchmark.Runner do
 
   @spec measure_runtimes(Scenario.t(), ScenarioContext.t(), number, boolean) :: [number]
   defp measure_runtimes(scenario, context, run_time, fast_warning)
-  defp measure_runtimes(_, _, 0.0, _), do: []
+  defp measure_runtimes(_, _, +0.0, _), do: []
 
   defp measure_runtimes(scenario, scenario_context, run_time, fast_warning) do
     end_time = current_time() + run_time

--- a/lib/benchee/output/benchmark_printer.ex
+++ b/lib/benchee/output/benchmark_printer.ex
@@ -94,7 +94,7 @@ defmodule Benchee.Output.BenchmarkPrinter do
   """
   def benchmarking(_, _, %{print: %{benchmarking: false}}), do: nil
 
-  def benchmarking(_, _, %{time: 0.0, warmup: 0.0, memory_time: 0.0, reduction_time: 0.0}),
+  def benchmarking(_, _, %{time: +0.0, warmup: +0.0, memory_time: +0.0, reduction_time: +0.0}),
     do: nil
 
   def benchmarking(name, input_name, _config) do

--- a/lib/benchee/relative_statistics.ex
+++ b/lib/benchee/relative_statistics.ex
@@ -95,8 +95,8 @@ defmodule Benchee.RelativeStatistics do
     }
   end
 
-  defp zero_safe_division(0.0, 0.0), do: 1.0
+  defp zero_safe_division(+0.0, +0.0), do: 1.0
   defp zero_safe_division(_, 0), do: :infinity
-  defp zero_safe_division(_, 0.0), do: :infinity
+  defp zero_safe_division(_, +0.0), do: :infinity
   defp zero_safe_division(a, b), do: a / b
 end

--- a/lib/benchee/statistics.ex
+++ b/lib/benchee/statistics.ex
@@ -224,7 +224,7 @@ defmodule Benchee.Statistics do
   end
 
   defp add_ips(statistics = %__MODULE__{sample_size: 0}), do: statistics
-  defp add_ips(statistics = %__MODULE__{average: 0.0}), do: statistics
+  defp add_ips(statistics = %__MODULE__{average: +0.0}), do: statistics
 
   defp add_ips(statistics) do
     ips = Duration.convert_value({1, :second}, :nanosecond) / statistics.average

--- a/lib/benchee/utility/file_creation.ex
+++ b/lib/benchee/utility/file_creation.ex
@@ -96,7 +96,7 @@ defmodule Benchee.Utility.FileCreation do
       ...>   ["Big Input", "Comparison", "great Stuff"])
       "bench/abc_big_input_comparison_great_stuff.csv"
 
-      iex> marker = Benchee.Benchmark.no_input
+      iex> marker = Benchee.Benchmark.no_input()
       iex> interleave("abc.csv", marker)
       "abc.csv"
       iex> interleave("abc.csv", [marker])

--- a/test/benchee/suite_test.exs
+++ b/test/benchee/suite_test.exs
@@ -67,9 +67,9 @@ defmodule Benchee.SuiteTest do
                 relative_less: nil,
                 relative_more: nil,
                 sample_size: 3,
-                std_dev: 0.0,
+                std_dev: +0.0,
                 std_dev_ips: nil,
-                std_dev_ratio: 0.0
+                std_dev_ratio: +0.0
               }
             },
             name: "Test 1",
@@ -113,9 +113,9 @@ defmodule Benchee.SuiteTest do
                 relative_less: nil,
                 relative_more: nil,
                 sample_size: 3,
-                std_dev: 0.0,
+                std_dev: +0.0,
                 std_dev_ips: nil,
-                std_dev_ratio: 0.0
+                std_dev_ratio: +0.0
               }
             },
             name: "Test 2",
@@ -168,9 +168,9 @@ defmodule Benchee.SuiteTest do
                 relative_less: nil,
                 relative_more: nil,
                 sample_size: 3,
-                std_dev: 0.0,
+                std_dev: +0.0,
                 std_dev_ips: nil,
-                std_dev_ratio: 0.0
+                std_dev_ratio: +0.0
               }
             },
             reductions_data: %Benchee.CollectionData{
@@ -186,9 +186,9 @@ defmodule Benchee.SuiteTest do
                 relative_less: nil,
                 relative_more: nil,
                 sample_size: 2,
-                std_dev: 0.0,
+                std_dev: +0.0,
                 std_dev_ips: nil,
-                std_dev_ratio: 0.0
+                std_dev_ratio: +0.0
               }
             },
             run_time_data: %Benchee.CollectionData{
@@ -273,7 +273,7 @@ defmodule Benchee.SuiteTest do
                     5881.0,
                     [1_792, 1_792, 1_792],
                     1_792.0,
-                    0.0,
+                    +0.0,
                     1_792.0,
                     1_792,
                     1_792,
@@ -297,7 +297,7 @@ defmodule Benchee.SuiteTest do
                     5881.0,
                     [1_792, 1_792, 1_792],
                     1_792.0,
-                    0.0,
+                    +0.0,
                     1_792.0,
                     1_792,
                     1_792,
@@ -366,7 +366,7 @@ defmodule Benchee.SuiteTest do
                     5881.0,
                     [1_792, 1_792, 1_792],
                     1_792.0,
-                    0.0,
+                    +0.0,
                     1_792.0,
                     1_792,
                     1_792,
@@ -376,7 +376,7 @@ defmodule Benchee.SuiteTest do
                     1_792.0,
                     [55, 55],
                     55.0,
-                    0.0,
+                    +0.0,
                     55.0,
                     55,
                     55,


### PR DESCRIPTION
https://erlangforums.com/t/in-erlang-otp-27-0-0-will-no-longer-be-exactly-equal-to-0-0/2586