### PR TITLE
Fix relative statistics calculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * System information now includes whether or not the JIT is enabled ([erlang docs](https://www.erlang.org/doc/apps/erts/beamasm)).
 * Benchee now let's you know when it's calculating statistics or running the formatters. Helps when you wonder what takes long or blows up memory.
 
+### Bugfixes (User Facing)
+* Fix a bug where relative statistics would always rely on the inputs provided in the config, which can break when you load saved benchmarks.
+
 ### Features (Plugins)
 * `jit_enabled?` is exposed as part of the `suite.system` struct
 * Yes, `Benchee.System` is now a struct so feel easier about relying on the fields

--- a/lib/benchee/relative_statistics.ex
+++ b/lib/benchee/relative_statistics.ex
@@ -55,7 +55,7 @@ defmodule Benchee.RelativeStatistics do
     grouped_scenarios = Enum.group_by(scenarios, & &1.input_name)
 
     Enum.map(original_input_order, fn input_name ->
-      Access.fetch!(grouped_scenarios, input_name)
+      Map.fetch!(grouped_scenarios, input_name)
     end)
   end
 


### PR DESCRIPTION
It used to rely on the inputs being there and then working based off on them - too bad, if we use `Benchee.load` then there are no inputs to go off, but they are still in the scenarios to work with them. Needs some care to preserve order which looks odd but couldn't find a better way.