### PR TITLE
Memory usage optimization / avoid sending unneeded data to parallel processing

### DIFF
--- a/lib/benchee/configuration.ex
+++ b/lib/benchee/configuration.ex
@@ -27,6 +27,7 @@ defmodule Benchee.Configuration do
               fast_warning: true
             },
             inputs: nil,
+            input_names: [],
             save: false,
             load: false,
             unit_scaling: :best,
@@ -150,6 +151,7 @@ defmodule Benchee.Configuration do
           formatters: [(Suite.t() -> Suite.t()) | module | {module, user_configuration}],
           print: map,
           inputs: %{Suite.key() => any} | [{Suite.key(), any}] | nil,
+          input_names: [String.t()],
           save: map | false,
           load: String.t() | [String.t()] | false,
           unit_scaling: Scale.scaling_strategy(),
@@ -184,6 +186,7 @@ defmodule Benchee.Configuration do
             time: 5_000_000_000.0,
             warmup: 2_000_000_000.0,
             inputs: nil,
+            input_names: [],
             save: false,
             load: false,
             formatters: [Benchee.Formatters.Console],
@@ -212,6 +215,7 @@ defmodule Benchee.Configuration do
             time: 1_000_000_000.0,
             warmup: 200_000_000.0,
             inputs: nil,
+            input_names: [],
             save: false,
             load: false,
             formatters: [Benchee.Formatters.Console],
@@ -240,6 +244,7 @@ defmodule Benchee.Configuration do
             time: 1_000_000_000.0,
             warmup: 200_000_000.0,
             inputs: nil,
+            input_names: [],
             save: false,
             load: false,
             formatters: [Benchee.Formatters.Console],
@@ -275,6 +280,7 @@ defmodule Benchee.Configuration do
             time: 1_000_000_000.0,
             warmup: 200_000_000.0,
             inputs: [{"Big", 9999}, {"Small", 5}],
+            input_names: ["Big", "Small"],
             save: false,
             load: false,
             formatters: [&IO.puts/1],
@@ -301,10 +307,11 @@ defmodule Benchee.Configuration do
 
     config =
       config
-      |> standardized_user_configuration
-      |> merge_with_defaults
-      |> convert_time_to_nano_s
-      |> save_option_conversion
+      |> standardized_user_configuration()
+      |> merge_with_defaults()
+      |> convert_time_to_nano_s()
+      |> save_option_conversion()
+      |> add_input_names()
 
     %Suite{configuration: config}
   end
@@ -334,6 +341,16 @@ defmodule Benchee.Configuration do
     else
       [{normalized_name, value} | acc]
     end
+  end
+
+  defp add_input_names(config) do
+    input_names =
+      case config.inputs do
+        nil -> []
+        inputs -> Enum.map(inputs, fn {name, _value} -> name end)
+      end
+
+    %{config | input_names: input_names}
   end
 
   defp merge_with_defaults(user_config) do

--- a/lib/benchee/configuration.ex
+++ b/lib/benchee/configuration.ex
@@ -236,35 +236,6 @@ defmodule Benchee.Configuration do
         scenarios: []
       }
 
-      iex> init(%{time: 1, warmup: 0.2})
-      %Benchee.Suite{
-        configuration:
-          %Benchee.Configuration{
-            parallel: 1,
-            time: 1_000_000_000.0,
-            warmup: 200_000_000.0,
-            inputs: nil,
-            input_names: [],
-            save: false,
-            load: false,
-            formatters: [Benchee.Formatters.Console],
-            print: %{
-              benchmarking: true,
-              fast_warning: true,
-              configuration: true
-            },
-            percentiles: [50, 99],
-            unit_scaling: :best,
-            assigns: %{},
-            before_each: nil,
-            after_each: nil,
-            before_scenario: nil,
-            after_scenario: nil
-          },
-        system: nil,
-        scenarios: []
-      }
-
       iex> init(
       ...>   parallel: 2,
       ...>   time: 1,

--- a/lib/benchee/configuration.ex
+++ b/lib/benchee/configuration.ex
@@ -147,7 +147,7 @@ defmodule Benchee.Configuration do
           memory_time: number,
           reduction_time: number,
           pre_check: boolean,
-          formatters: [(Suite.t() -> Suite.t()) | module | {module, map}],
+          formatters: [(Suite.t() -> Suite.t()) | module | {module, user_configuration}],
           print: map,
           inputs: %{Suite.key() => any} | [{Suite.key(), any}] | nil,
           save: map | false,

--- a/lib/benchee/formatter.ex
+++ b/lib/benchee/formatter.ex
@@ -172,12 +172,26 @@ defmodule Benchee.Formatter do
   # Hence, we scrub them away here. If you maintain a formatter plugin and rely on these please
   # get in touch so we can work on a solution.
   defp scrub_suite(suite) do
-    update_in(suite.scenarios, fn scenarios ->
-      Enum.map(scenarios, &scrub_scenario/1)
-    end)
+    suite =
+      update_in(suite.scenarios, fn scenarios ->
+        Enum.map(scenarios, &scrub_scenario/1)
+      end)
+
+    update_in(suite.configuration, &scrub_configuration/1)
   end
 
   defp scrub_scenario(scenario) do
     %Scenario{scenario | function: nil, input: nil}
+  end
+
+  defp scrub_configuration(configuration) do
+    update_in(configuration.inputs, &scrub_inputs/1)
+  end
+
+  defp scrub_inputs(nil), do: nil
+  # Feels somewhat hacky, but while people should not be relying on the input itself, they
+  # may be relying on the input names/order
+  defp scrub_inputs(inputs) do
+    Enum.map(inputs, fn {name, _value} -> {name, :scrubbed_see_1_3_0_changelog} end)
   end
 end

--- a/lib/benchee/formatter.ex
+++ b/lib/benchee/formatter.ex
@@ -20,12 +20,35 @@ defmodule Benchee.Formatter do
   """
   @type options :: any
 
+  @typedoc """
+  A suite scrubbed of heavy data.
+
+  Type to bring awareness to the fact that `format/2` doesn't have access to
+  _all_ data in `Benchee.Suite` - please read the docs for `format/2` to learn
+  more.
+  """
+  @type scrubbed_suite :: Suite.t()
+
   @doc """
+  Takes a suite and returns a representation `write/2` can use.
+
   Takes the suite and returns whatever representation the formatter wants to use
   to output that information. It is important that this function **needs to be
   pure** (aka have no side effects) as Benchee will run `format/1` functions
   of multiple formatters in parallel. The result will then be passed to
-  `write/1`.
+  `write/2`.
+
+  **Note:** Due to memory consumption issues in benchmarks with big inputs, the suite
+  passed to the formatters **is missing anything referencing big input data** to avoid
+  huge memory consumption and run time. Namely this constitutes:
+  * `Benchee.Scenario` will have `function` and `input` set to `nil`
+  * `Benchee.Configuration` will have `inputs`, but it won't have values only the names,
+  it may be removed in the future please use `input_names` instead if needed (or
+  `input_name` of `Benchee.Scenario`)
+
+  Technically speaking this "scrubbing" of `Benchee.Suite` only occurs when formatters
+  are run in parallel, you still shouldn't rely on those values (and they should not
+  be needed). If you do need them for some reason, please get in touch/open an issue.
   """
   @callback format(Suite.t(), options) :: any
 

--- a/lib/benchee/formatter.ex
+++ b/lib/benchee/formatter.ex
@@ -153,6 +153,7 @@ defmodule Benchee.Formatter do
   # the results of that formatting are written in sequence.
   defp parallel_output(suite, module_configurations) do
     module_configurations
+    # clean up the suite
     |> Parallel.map(fn {module, options} -> {module, options, module.format(suite, options)} end)
     |> Enum.each(fn {module, options, output} -> module.write(output, options) end)
 

--- a/lib/benchee/formatter.ex
+++ b/lib/benchee/formatter.ex
@@ -80,9 +80,7 @@ defmodule Benchee.Formatter do
       |> Enum.map(&normalize_module_configuration/1)
       |> Enum.split_with(&is_tuple/1)
 
-    # why do we ignore this suite? It shouldn't be changed anyway.
-    # We assign it because dialyzer would complain otherwise :D
-    _suite = parallel_output(suite, parallelizable)
+    parallel_output(suite, parallelizable)
 
     Enum.each(serial, fn function -> function.(suite) end)
 

--- a/lib/benchee/statistics.ex
+++ b/lib/benchee/statistics.ex
@@ -197,27 +197,25 @@ defmodule Benchee.Statistics do
 
   defp update_scenarios_with_statistics(scenarios, scenario_statistics) do
     # we can zip them as they retained order
-    Enum.zip_with(
-      scenarios,
-      scenario_statistics,
-      fn scenario, {run_time_stats, memory_stats, reductions_stats} ->
-        %Scenario{
-          scenario
-          | run_time_data: %CollectionData{
-              scenario.run_time_data
-              | statistics: run_time_stats
-            },
-            memory_usage_data: %CollectionData{
-              scenario.memory_usage_data
-              | statistics: memory_stats
-            },
-            reductions_data: %CollectionData{
-              scenario.reductions_data
-              | statistics: reductions_stats
-            }
-        }
-      end
-    )
+    scenarios
+    |> Enum.zip(scenario_statistics)
+    |> Enum.map(fn {scenario, {run_time_stats, memory_stats, reductions_stats}} ->
+      %Scenario{
+        scenario
+        | run_time_data: %CollectionData{
+            scenario.run_time_data
+            | statistics: run_time_stats
+          },
+          memory_usage_data: %CollectionData{
+            scenario.memory_usage_data
+            | statistics: memory_stats
+          },
+          reductions_data: %CollectionData{
+            scenario.reductions_data
+            | statistics: reductions_stats
+          }
+      }
+    end)
   end
 
   defp calculate_scenario_statistics({run_time_data, memory_data, reductions_data}, percentiles) do

--- a/test/benchee/configuration_test.exs
+++ b/test/benchee/configuration_test.exs
@@ -41,6 +41,11 @@ defmodule Benchee.ConfigurationTest do
                init(inputs: %{"A" => 1, "B" => 2})
     end
 
+    test "input_names are normalized" do
+      assert %Suite{configuration: %{input_names: ["a"]}} =
+               init(inputs: %{a: 1})
+    end
+
     test "no inputs, no input_names" do
       assert %Suite{configuration: %{input_names: []}} = init()
     end

--- a/test/benchee/configuration_test.exs
+++ b/test/benchee/configuration_test.exs
@@ -29,6 +29,22 @@ defmodule Benchee.ConfigurationTest do
                init(inputs: %{"map" => %{}, map: %{}})
     end
 
+    test "keeps ordered inputs basically as is" do
+      input_list = [{"map", %{}}, {"A", 1}]
+
+      assert %Suite{configuration: %{inputs: ^input_list}} =
+               init(inputs: input_list)
+    end
+
+    test "documents input_names" do
+      assert %Suite{configuration: %{input_names: ["A", "B"]}} =
+               init(inputs: %{"A" => 1, "B" => 2})
+    end
+
+    test "no inputs, no input_names" do
+      assert %Suite{configuration: %{input_names: []}} = init()
+    end
+
     test "uses information from :save to setup the external term formattter" do
       assert %Suite{
                configuration: %{

--- a/test/benchee/formatter_test.exs
+++ b/test/benchee/formatter_test.exs
@@ -1,13 +1,16 @@
 defmodule Benchee.FormatterTest do
   use ExUnit.Case, async: true
-  alias Benchee.{Formatter, Suite, Test.FakeFormatter}
+  alias Benchee.{Configuration, Formatter, Suite, Test.FakeFormatter}
 
   @no_print_assigns %{test: %{progress_printer: Benchee.Test.FakeProgressPrinter}}
 
   describe "output/1" do
     test "calls `write/1` with the output of `format/1` on each module" do
       Formatter.output(%Suite{
-        configuration: %{formatters: [{FakeFormatter, %{}}], assigns: @no_print_assigns}
+        configuration: %Configuration{
+          formatters: [{FakeFormatter, %{}}],
+          assigns: @no_print_assigns
+        }
       })
 
       assert_receive {:write, "output of `format/1` with %{}", %{}}
@@ -15,7 +18,7 @@ defmodule Benchee.FormatterTest do
 
     test "works with just modules without option tuple, defaults to empty map" do
       Formatter.output(%Suite{
-        configuration: %{formatters: [FakeFormatter], assigns: @no_print_assigns}
+        configuration: %Configuration{formatters: [FakeFormatter], assigns: @no_print_assigns}
       })
 
       assert_receive {:write, "output of `format/1` with %{}", %{}}
@@ -23,7 +26,10 @@ defmodule Benchee.FormatterTest do
 
     test "options are passed on correctly" do
       Formatter.output(%Suite{
-        configuration: %{formatters: [{FakeFormatter, %{a: :b}}], assigns: @no_print_assigns}
+        configuration: %Configuration{
+          formatters: [{FakeFormatter, %{a: :b}}],
+          assigns: @no_print_assigns
+        }
       })
 
       assert_receive {:write, "output of `format/1` with %{a: :b}", %{a: :b}}
@@ -31,7 +37,10 @@ defmodule Benchee.FormatterTest do
 
     test "keyword list options are deep converted to maps" do
       Formatter.output(%Suite{
-        configuration: %{formatters: [{FakeFormatter, [a: [b: :c]]}], assigns: @no_print_assigns}
+        configuration: %Configuration{
+          formatters: [{FakeFormatter, [a: [b: :c]]}],
+          assigns: @no_print_assigns
+        }
       })
 
       assert_receive {:write, "output of `format/1` with %{a: %{b: :c}}", %{a: %{b: :c}}}
@@ -39,7 +48,7 @@ defmodule Benchee.FormatterTest do
 
     test "mixing functions and formatters works" do
       suite = %Suite{
-        configuration: %{
+        configuration: %Configuration{
           formatters: [
             {FakeFormatter, %{}},
             fn suite -> send(self(), {:fun, suite, "me"}) end
@@ -56,7 +65,10 @@ defmodule Benchee.FormatterTest do
 
     test "returns the suite passed in as the first argument unchanged" do
       suite = %Suite{
-        configuration: %{formatters: [{FakeFormatter, %{}}], assigns: @no_print_assigns}
+        configuration: %Configuration{
+          formatters: [{FakeFormatter, %{}}],
+          assigns: @no_print_assigns
+        }
       }
 
       assert Formatter.output(suite) == suite
@@ -64,7 +76,7 @@ defmodule Benchee.FormatterTest do
 
     test "lets you know it starts formatting now" do
       Formatter.output(%Suite{
-        configuration: %{formatters: [], assigns: @no_print_assigns}
+        configuration: %Configuration{formatters: [], assigns: @no_print_assigns}
       })
 
       assert_received :formatting

--- a/test/benchee/formatters/tagged_save_test.exs
+++ b/test/benchee/formatters/tagged_save_test.exs
@@ -63,7 +63,7 @@ defmodule Benchee.Formatters.TaggedSaveTest do
       loaded_suite =
         binary
         |> :erlang.binary_to_term()
-        |> suite_without_scenario_tags
+        |> suite_without_scenario_tags()
 
       assert loaded_suite == @suite
       assert path == @filename
@@ -158,7 +158,7 @@ defmodule Benchee.Formatters.TaggedSaveTest do
       loaded_suite =
         etf_data
         |> :erlang.binary_to_term()
-        |> suite_without_scenario_tags
+        |> suite_without_scenario_tags()
 
       assert loaded_suite == @suite
     after

--- a/test/benchee/statistics_test.exs
+++ b/test/benchee/statistics_test.exs
@@ -8,6 +8,10 @@ defmodule Benchee.StatistcsTest do
 
   @sample_1 [600, 470, 170, 430, 300]
   @sample_2 [17, 15, 23, 7, 9, 13]
+  @sample_3 [5]
+  @sample_4 [100, 100, 100, 100]
+  @sample_5 [5, 10, 15]
+  @sample_6 [10, 20]
   describe ".statistics" do
     test "computes the statistics for all jobs correctly" do
       scenarios = [
@@ -16,25 +20,37 @@ defmodule Benchee.StatistcsTest do
           input_name: "Input",
           job_name: "Job 1",
           run_time_data: %CollectionData{samples: @sample_1},
-          memory_usage_data: %CollectionData{samples: @sample_1}
+          memory_usage_data: %CollectionData{samples: @sample_3},
+          reductions_data: %CollectionData{samples: @sample_5}
         },
         %Scenario{
           input: "Input",
           input_name: "Input",
           job_name: "Job 2",
           run_time_data: %CollectionData{samples: @sample_2},
-          memory_usage_data: %CollectionData{samples: @sample_2}
+          memory_usage_data: %CollectionData{samples: @sample_4},
+          reductions_data: %CollectionData{samples: @sample_6}
         }
       ]
 
       suite = %Suite{scenarios: scenarios}
       new_suite = Statistics.statistics(suite, FakeProgressPrinter)
 
-      stats_1 = stats_for(new_suite, "Job 1", "Input")
-      stats_2 = stats_for(new_suite, "Job 2", "Input")
+      stats_1 = run_time_stats_for(new_suite, "Job 1", "Input")
+      stats_2 = run_time_stats_for(new_suite, "Job 2", "Input")
+
+      stats_3 = stats_for(new_suite, "Job 1", "Input", :memory_usage_data)
+      stats_4 = stats_for(new_suite, "Job 2", "Input", :memory_usage_data)
+
+      stats_5 = stats_for(new_suite, "Job 1", "Input", :reductions_data)
+      stats_6 = stats_for(new_suite, "Job 2", "Input", :reductions_data)
 
       sample_1_asserts(stats_1)
       sample_2_asserts(stats_2)
+      sample_3_asserts(stats_3)
+      sample_4_asserts(stats_4)
+      sample_5_asserts(stats_5)
+      sample_6_asserts(stats_6)
     end
 
     test "computes statistics correctly for multiple inputs" do
@@ -78,10 +94,10 @@ defmodule Benchee.StatistcsTest do
 
       new_suite = Statistics.statistics(suite, FakeProgressPrinter)
 
-      stats_1_1 = stats_for(new_suite, "Job 1", "Input 1")
-      stats_1_2 = stats_for(new_suite, "Job 2", "Input 1")
-      stats_2_1 = stats_for(new_suite, "Job 1", "Input 2")
-      stats_2_2 = stats_for(new_suite, "Job 2", "Input 2")
+      stats_1_1 = run_time_stats_for(new_suite, "Job 1", "Input 1")
+      stats_1_2 = run_time_stats_for(new_suite, "Job 2", "Input 1")
+      stats_2_1 = run_time_stats_for(new_suite, "Job 1", "Input 2")
+      stats_2_2 = run_time_stats_for(new_suite, "Job 2", "Input 2")
 
       sample_1_asserts(stats_1_1)
       sample_2_asserts(stats_1_2)
@@ -164,7 +180,8 @@ defmodule Benchee.StatistcsTest do
       scenarios = [
         %Scenario{
           run_time_data: %CollectionData{samples: @nothing},
-          memory_usage_data: %CollectionData{samples: @nothing}
+          memory_usage_data: %CollectionData{samples: @nothing},
+          reductions_data: %CollectionData{samples: @nothing}
         }
       ]
 
@@ -173,15 +190,18 @@ defmodule Benchee.StatistcsTest do
       [
         %Scenario{
           run_time_data: %CollectionData{statistics: run_time_stats},
-          memory_usage_data: %CollectionData{statistics: memory_stats}
+          memory_usage_data: %CollectionData{statistics: memory_stats},
+          reductions_data: %CollectionData{statistics: reductions_stats}
         }
       ] = suite.scenarios
 
       assert run_time_stats.sample_size == 0
       assert memory_stats.sample_size == 0
+      assert reductions_stats.sample_size == 0
 
       assert run_time_stats.average == nil
       assert memory_stats.average == nil
+      assert reductions_stats.average == nil
     end
 
     test "lets you know it's benchmarking" do
@@ -190,20 +210,26 @@ defmodule Benchee.StatistcsTest do
       assert_received :calculating_statistics
     end
 
-    defp stats_for(suite, job_name, input_name) do
-      %Scenario{run_time_data: %CollectionData{statistics: stats}} =
-        Enum.find(suite.scenarios, fn scenario ->
-          scenario.job_name == job_name && scenario.input_name == input_name
-        end)
-
-      stats
+    defp run_time_stats_for(suite, job_name, input_name) do
+      stats_for(suite, job_name, input_name, :run_time_data)
     end
 
-    defp sample_1_asserts(stats) do
+    defp stats_for(suite, job_name, input_name, access_key) do
+      collection_data =
+        suite.scenarios
+        |> Enum.find(fn scenario ->
+          scenario.job_name == job_name && scenario.input_name == input_name
+        end)
+        |> Map.get(access_key)
+
+      collection_data.statistics
+    end
+
+    defp sample_1_asserts(stats, opts \\ []) do
       assert stats.average == 394.0
       assert_in_delta stats.std_dev, 164.71, 0.01
       assert_in_delta stats.std_dev_ratio, 0.41, 0.01
-      assert_in_delta stats.ips, 2_538_071, 1
+      if Access.get(opts, :show_ips), do: assert_in_delta(stats.ips, 2_538_071, 1)
       assert stats.median == 430.0
       assert stats.minimum == 170
       assert stats.maximum == 600
@@ -211,15 +237,59 @@ defmodule Benchee.StatistcsTest do
       assert stats.mode == nil
     end
 
-    defp sample_2_asserts(stats) do
+    defp sample_2_asserts(stats, opts \\ []) do
       assert stats.average == 14.0
       assert_in_delta stats.std_dev, 5.76, 0.01
       assert_in_delta stats.std_dev_ratio, 0.41, 0.01
-      assert_in_delta stats.ips, 71_428_571, 1
+      if Access.get(opts, :show_ips), do: assert_in_delta(stats.ips, 71_428_571, 1)
       assert stats.median == 14.0
       assert stats.minimum == 7
       assert stats.maximum == 23
       assert stats.sample_size == 6
+      assert stats.mode == nil
+    end
+
+    defp sample_3_asserts(stats) do
+      assert stats.average == 5.0
+      assert stats.std_dev == 0.0
+      assert stats.std_dev_ratio == 0.0
+      assert stats.median == 5.0
+      assert stats.minimum == 5
+      assert stats.maximum == 5
+      assert stats.sample_size == 1
+      assert stats.mode == nil
+    end
+
+    defp sample_4_asserts(stats) do
+      assert stats.average == 100.0
+      assert stats.std_dev == 0.0
+      assert stats.std_dev_ratio == 0.0
+      assert stats.median == 100.0
+      assert stats.minimum == 100
+      assert stats.maximum == 100
+      assert stats.sample_size == 4
+      assert stats.mode == 100
+    end
+
+    defp sample_5_asserts(stats) do
+      assert stats.average == 10.0
+      assert stats.std_dev == 5.0
+      assert stats.std_dev_ratio == 0.5
+      assert stats.median == 10.0
+      assert stats.minimum == 5
+      assert stats.maximum == 15
+      assert stats.sample_size == 3
+      assert stats.mode == nil
+    end
+
+    defp sample_6_asserts(stats) do
+      assert stats.average == 15.0
+      assert_in_delta stats.std_dev, 7.07, 0.01
+      assert_in_delta stats.std_dev_ratio, 0.47, 0.01
+      assert stats.median == 15.0
+      assert stats.minimum == 10
+      assert stats.maximum == 20
+      assert stats.sample_size == 2
       assert stats.mode == nil
     end
   end

--- a/test/benchee_test.exs
+++ b/test/benchee_test.exs
@@ -658,9 +658,9 @@ defmodule BencheeTest do
           untagged_suite =
             content
             |> :erlang.binary_to_term()
-            |> suite_without_scenario_tags
+            |> suite_without_scenario_tags()
 
-          assert untagged_suite == suite
+          assert untagged_suite == without_functions_and_inputs(suite)
         end)
 
         loaded_output =
@@ -692,6 +692,16 @@ defmodule BencheeTest do
           File.rm!(expected_file)
         end
       end
+    end
+
+    # function and input provide no real benefit for the envisioned use case of comparing outputs
+    # what it does is balloon the file size written out and take performance to the groun
+    defp without_functions_and_inputs(suite) do
+      update_in(suite.scenarios, fn scenarios ->
+        Enum.map(scenarios, fn scenario ->
+          %Benchee.Scenario{scenario | function: nil, input: nil}
+        end)
+      end)
     end
 
     test " report/1 raises without providing at least a load option" do


### PR DESCRIPTION
Should combat memory consumption issues caused by sending too much data to processes.

edit: To highlight the severeness of this:

* there is a benchmark I'm working on that I almost couldn't run before this as my 32GB of RAM would not be enough
  * benchmark is this one: https://github.com/PragTob/tco_elixir
* it also hung forever before calculating statistics and running the formatters
* In that benchmark I used `:save` to compare performance across elixir version, before this PR each individual save file was 200+MB. With this MR, it's 1MB (as it removes the data from formatters and `:save` is a formatter under the hood). The file size isn't the major thing, but it illustrates how much memory we save and how much time copying memory we avoid. 

I wanna write up all of this in like 2 blog posts but as per usual my speed is abysmal 😁 