### PR TITLE
Trigger build to diagnose issue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,7 +83,7 @@ jobs:
         run: MIX_ENV=test mix coveralls.github --warnings-as-errors || mix test --failed
         if: contains(matrix.elixir_version, '1.15')
       - name: Dialyzer
-        run: mix dialyzer --halt-exit-status
+        run: mix dialyzer --halt-exit-status --force-check --format github
         if: contains(matrix.elixir_version, '1.15')
 
   macos:


### PR DESCRIPTION
So #415 is failing and it shouldn't, see:

https://github.com/bencheeorg/benchee/actions/runs/7259274594/job/19776364305?pr=415

Error is weird/missing cache or something?

> :dialyzer.run error: File not found: /opt/hostedtoolcache/otp/ubuntu-20.04/OTP-24.3.4.14/x64/lib/dialyzer-4.4.4.1/ebin/erl_bif_types.beam

See if it's also happening here!