### PR TITLE
Drobnyd human friendlier format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * System information now includes whether or not the JIT is enabled ([erlang docs](https://www.erlang.org/doc/apps/erts/beamasm)).
 * Benchee now let's you know when it's calculating statistics or running the formatters. Helps when you wonder what takes long or blows up memory.
 * `Benchee.report/1` got introduced if you just want to load saves benchmarks and report on them.
+* Configuration times will now be displayed in a more human friendly format (1min 12s vs. 1.2min). Thanks to [@drobnyd](https://github.com/drobnyd).
 
 ### Bugfixes (User Facing)
 * Memory usage should be massively reduced when dealing with larger sets of data in inputs or benchmarking functions. They were needlessly sent to processes calculating statistics or formatters which could lead to memory blowing up.
@@ -26,11 +27,10 @@ Woopsie, didn't wanna do any of these in 1.x, sorry but there's good reason :(
   * Technically speaking formatters haven't generally lost access, only if they are processed in parallel - so not if it's the only formatter or if it's used via a function (`formatters: [fn suite -> MyFormatter.output(suite) end]`. Still, should not be used or relied upon.
 
 ### Features (Plugins)
-* `Configuration` now has an `input_names` key that holds the name of all inputs, for the reasoning, see above.
-
-### Features (Plugins)
 * `jit_enabled?` is exposed as part of the `suite.system` struct
 * Yes, `Benchee.System` is now a struct so feel easier about relying on the fields
+* `Configuration` now has an `input_names` key that holds the name of all inputs, for the reasoning, see above.
+* The more human friendly formats are accessible via `Format.format_human/2` or `Duration.format_human/1` (& friends)
 
 ## 1.2.0 (2023-11-09)
 

--- a/lib/benchee/conversion/count.ex
+++ b/lib/benchee/conversion/count.ex
@@ -14,7 +14,7 @@ defmodule Benchee.Conversion.Count do
   @one_million 1_000_000
   @one_thousand 1_000
 
-  @units %{
+  @units_map %{
     billion: %Unit{
       name: :billion,
       magnitude: @one_billion,
@@ -40,6 +40,8 @@ defmodule Benchee.Conversion.Count do
       long: ""
     }
   }
+
+  @units Map.values(@units_map)
 
   @type unit_atoms :: :one | :thousand | :million | :billion
   @type units :: unit_atoms | Unit.t()
@@ -111,7 +113,11 @@ defmodule Benchee.Conversion.Count do
       }
   """
   def unit_for(unit) do
-    Scale.unit_for(@units, unit)
+    Scale.unit_for(@units_map, unit)
+  end
+
+  def units do
+    @units
   end
 
   @doc """
@@ -191,8 +197,9 @@ defmodule Benchee.Conversion.Count do
   def base_unit, do: unit_for(:one)
 
   @doc """
-  Formats a number as a string, with a unit label. To specify the unit, pass
-  a tuple of `{value, unit_atom}` like `{1_234, :million}`
+  Formats a number as a string, with a unit label.
+
+  To specify the unit, pass a tuple of `{value, unit_atom}` like `{1_234, :million}`
 
   ## Examples
 
@@ -210,5 +217,23 @@ defmodule Benchee.Conversion.Count do
   """
   def format(count) do
     Format.format(count, __MODULE__)
+  end
+
+  @doc """
+  Formats in a more "human" way separating by units.
+
+  ## Examples
+
+      iex> format_human(45_678.9)
+      "45 K 678.90"
+
+      iex> format_human(1_000_000)
+      "1 M"
+
+      iex> format_human(1_001_000)
+      "1 M 1 K"
+  """
+  def format_human(count) do
+    Format.format_human(count, __MODULE__)
   end
 end

--- a/lib/benchee/conversion/deviation_percent.ex
+++ b/lib/benchee/conversion/deviation_percent.ex
@@ -11,9 +11,10 @@ defmodule Benchee.Conversion.DeviationPercent do
   @behaviour Format
 
   @doc """
-  Formats the standard deviation ratio to an equivalent percent number
-  including special signs. The ± is an important part of it as it shows that
-  the deviation might be up but also might be down.
+  Formats the standard deviation ratio to an equivalent percent number including special signs.
+
+  The ± is an important part of it as it shows that the deviation might be up but also might be
+  down.
 
   ## Examples
 
@@ -27,5 +28,19 @@ defmodule Benchee.Conversion.DeviationPercent do
     "~ts~.2f%"
     |> :io_lib.format(["±", std_dev_ratio * 100.0])
     |> to_string
+  end
+
+  @doc """
+  Formats standard deviation percent, same as `format/1`.
+
+  Implemented for consistency.
+
+  ## Examples
+
+      iex> format_human(0.1)
+      "±10.00%"
+  """
+  def format_human(std_dev_ratio) do
+    format(std_dev_ratio)
   end
 end

--- a/lib/benchee/conversion/duration.ex
+++ b/lib/benchee/conversion/duration.ex
@@ -264,24 +264,25 @@ defmodule Benchee.Conversion.Duration do
   end
 
   @doc """
-  Formats a number as a string.
+  Human friendly duration format for time as a string.
+
   The output is a sequence of values and unit labels separated by a space.
   Only units whose value is non-zero are included in the output.
   The passed number is duration in the base unit - nanoseconds.
 
-      iex> Benchee.Conversion.Duration.format_verbose(5_400_000_000_000)
+      iex> Benchee.Conversion.Duration.format_human(5_400_000_000_000)
       "1 h 30 min"
 
-      iex> Benchee.Conversion.Duration.format_verbose(12.5)
+      iex> Benchee.Conversion.Duration.format_human(12.5)
       "12.50 ns"
 
-      iex> Benchee.Conversion.Duration.format_verbose(3_660_001_001_000)
+      iex> Benchee.Conversion.Duration.format_human(3_660_001_001_000)
       "1 h 1 min 1 ms 1 μs"
   """
-  def format_verbose(number) when is_number(number) do
+  def format_human(number) when is_number(number) do
     number
     |> place_values()
-    |> Enum.map_join(" ", &format(&1))
+    |> Enum.map_join(" ", &format/1)
   end
 
   # Returns a list of place vaules with corresponding units for the `number`.

--- a/lib/benchee/conversion/duration.ex
+++ b/lib/benchee/conversion/duration.ex
@@ -307,7 +307,7 @@ defmodule Benchee.Conversion.Duration do
   defp place_values(number, [base_unit]), do: [{number, base_unit}]
 
   defp place_values(number, [unit | units]) do
-    place_value = floor(number)
+    place_value = trunc(number)
     decimal_carry = number - place_value
     int_carry = rem(place_value, unit.magnitude)
 

--- a/lib/benchee/conversion/duration.ex
+++ b/lib/benchee/conversion/duration.ex
@@ -288,6 +288,9 @@ defmodule Benchee.Conversion.Duration do
 
       iex> format_human(0)
       "0 ns"
+
+      iex> format_human(2 * 1000 * 1000 * 1000)
+      "2 s"
   """
   def format_human(duration) do
     Format.format_human(duration, __MODULE__)

--- a/lib/benchee/conversion/duration.ex
+++ b/lib/benchee/conversion/duration.ex
@@ -143,6 +143,10 @@ defmodule Benchee.Conversion.Duration do
     Scale.unit_for(@units, unit)
   end
 
+  def units do
+    @units
+  end
+
   @doc """
   Scales a duration value in nanoseconds into a value in the specified unit
 
@@ -264,57 +268,22 @@ defmodule Benchee.Conversion.Duration do
   end
 
   @doc """
-  Human friendly duration format for time as a string.
+  iex> format_human(5_400_000_000_000)
+  "1 h 30 min"
 
-  The output is a sequence of values and unit labels separated by a space.
-  Only units whose value is non-zero are included in the output.
-  The passed number is duration in the base unit - nanoseconds.
+  iex> format_human(12.5)
+  "12.50 ns"
 
-      iex> Benchee.Conversion.Duration.format_human(5_400_000_000_000)
-      "1 h 30 min"
+  iex> format_human(1000.555)
+  "1 μs 0.55 ns"
 
-      iex> Benchee.Conversion.Duration.format_human(12.5)
-      "12.50 ns"
+  iex> format_human(3_660_001_001_000)
+  "1 h 1 min 1 ms 1 μs"
 
-      iex> Benchee.Conversion.Duration.format_human(3_660_001_001_000)
-      "1 h 1 min 1 ms 1 μs"
+  iex> format_human(0)
+  "0 ns"
   """
-  def format_human(number) when is_number(number) do
-    number
-    |> place_values()
-    |> Enum.map_join(" ", &format/1)
-  end
-
-  # Returns a list of place vaules with corresponding units for the `number`.
-  # The output is sorted descending by magnitude of units and excludes tuples with place value 0.
-  # Place values are `non_neg_integer` for non-base units,
-  # however base unit may also be `float` becuase the decimals can't be split further.
-  @spec place_values(number) :: [{number, Scale.unit()}]
-  defp place_values(number) do
-    desc_units =
-      @units
-      |> Map.values()
-      |> Enum.sort(&(&1.magnitude >= &2.magnitude))
-
-    case place_values(number, desc_units) do
-      [] -> [{0, base_unit()}]
-      res -> res
-    end
-  end
-
-  @spec place_values(number, [Scale.unit()]) :: [{number, Scale.unit()}]
-  defp place_values(0, _units), do: []
-
-  defp place_values(number, [base_unit]), do: [{number, base_unit}]
-
-  defp place_values(number, [unit | units]) do
-    place_value = trunc(number)
-    decimal_carry = number - place_value
-    int_carry = rem(place_value, unit.magnitude)
-
-    case div(place_value, unit.magnitude) do
-      0 -> place_values(int_carry + decimal_carry, units)
-      place_value -> [{place_value, unit} | place_values(int_carry + decimal_carry, units)]
-    end
+  def format_human(duration) do
+    Format.format_human(duration, __MODULE__)
   end
 end

--- a/lib/benchee/conversion/duration.ex
+++ b/lib/benchee/conversion/duration.ex
@@ -21,7 +21,7 @@ defmodule Benchee.Conversion.Duration do
   @nanoseconds_per_minute @nanoseconds_per_second * @seconds_per_minute
   @nanoseconds_per_hour @nanoseconds_per_minute * @minutes_per_hour
 
-  @units %{
+  @units_map %{
     hour: %Unit{
       name: :hour,
       magnitude: @nanoseconds_per_hour,
@@ -59,6 +59,8 @@ defmodule Benchee.Conversion.Duration do
       long: "Nanoseconds"
     }
   }
+
+  @units Map.values(@units_map)
 
   @doc """
   Scales a duration value in nanoseconds into a larger unit if appropriate
@@ -140,7 +142,7 @@ defmodule Benchee.Conversion.Duration do
       }
   """
   def unit_for(unit) do
-    Scale.unit_for(@units, unit)
+    Scale.unit_for(@units_map, unit)
   end
 
   def units do
@@ -268,20 +270,24 @@ defmodule Benchee.Conversion.Duration do
   end
 
   @doc """
-  iex> format_human(5_400_000_000_000)
-  "1 h 30 min"
+  Formats in a more "human" way - 1h 30min instead of 1.5h.
 
-  iex> format_human(12.5)
-  "12.50 ns"
+  ## Examples
 
-  iex> format_human(1000.555)
-  "1 μs 0.55 ns"
+      iex> format_human(5_400_000_000_000)
+      "1 h 30 min"
 
-  iex> format_human(3_660_001_001_000)
-  "1 h 1 min 1 ms 1 μs"
+      iex> format_human(12.5)
+      "12.50 ns"
 
-  iex> format_human(0)
-  "0 ns"
+      iex> format_human(1000.555)
+      "1 μs 0.55 ns"
+
+      iex> format_human(3_660_001_001_000)
+      "1 h 1 min 1 ms 1 μs"
+
+      iex> format_human(0)
+      "0 ns"
   """
   def format_human(duration) do
     Format.format_human(duration, __MODULE__)

--- a/lib/benchee/conversion/format.ex
+++ b/lib/benchee/conversion/format.ex
@@ -67,6 +67,60 @@ defmodule Benchee.Conversion.Format do
     |> format
   end
 
+  @doc """
+  Human friendly duration format for time as a string.
+
+  The output is a sequence of values and unit labels separated by a space.
+  Only units whose value is non-zero are included in the output.
+  The passed number is duration in the base unit - nanoseconds.
+  """
+  def format_human(0, module) do
+    format(0, module)
+  end
+
+  def format_human(number, module) when is_number(number) do
+    number
+    |> split_into_place_values(module)
+    |> Enum.map_join(" ", &format/1)
+  end
+
+  # Returns a list of place vaules with corresponding units for the `number`.
+  # The output is sorted descending by magnitude of units and excludes tuples with place value 0.
+  # Place values are `non_neg_integer` for non-base units,
+  # however base unit may also be `float` becuase the decimals can't be split further.
+  @spec split_into_place_values(number, module) :: [{number, Scale.unit()}]
+  defp split_into_place_values(number, module) do
+    descending_units = units_descending(module)
+
+    place_values(number, descending_units)
+  end
+
+  defp units_descending(module) do
+    module.units()
+    |> Map.values()
+    |> Enum.sort(&(&1.magnitude >= &2.magnitude))
+  end
+
+  @spec place_values(number, [Scale.unit()]) :: [{number, Scale.unit()}]
+  defp place_values(0, _units), do: []
+
+  # smalles unit, carries the decimal
+  defp place_values(number, [base_unit = %Unit{magnitude: 1}]), do: [{number, base_unit}]
+
+  defp place_values(number, [unit | units]) do
+    integer_number = trunc(number)
+    decimal_carry = number - integer_number
+    int_carry = rem(integer_number, unit.magnitude)
+    carry = decimal_carry + int_carry
+
+    place_value = div(integer_number, unit.magnitude)
+
+    case place_value do
+      0 -> place_values(carry, units)
+      place_value -> [{place_value, unit} | place_values(carry, units)]
+    end
+  end
+
   @default_separator " "
   # should we need it again, a customer separator could be returned
   # per module here

--- a/lib/benchee/conversion/format.ex
+++ b/lib/benchee/conversion/format.ex
@@ -14,24 +14,31 @@ defmodule Benchee.Conversion.Format do
   """
   @callback format(number) :: String.t()
 
+  @doc """
+  Formats in a more "human" way, one biggest unit at a time.
+
+  So instead of 1.5h it says 1h 30min
+  """
+  @callback format_human(number) :: String.t()
+
   # Generic formatting functions
 
   @doc """
   Formats a unit value with specified label and separator
   """
-  def format(count, label, separator) do
+  def format(number, label, separator) do
     separator = separator(label, separator)
-    "#{number_format(count)}#{separator}#{label}"
+    "#{number_format(number)}#{separator}#{label}"
   end
 
-  defp number_format(count) when is_float(count) do
-    count
-    |> :erlang.float_to_list(decimals: float_precision(count))
+  defp number_format(number) when is_float(number) do
+    number
+    |> :erlang.float_to_list(decimals: float_precision(number))
     |> to_string
   end
 
-  defp number_format(count) when is_integer(count) do
-    to_string(count)
+  defp number_format(number) when is_integer(number) do
+    to_string(number)
   end
 
   @doc """
@@ -49,16 +56,16 @@ defmodule Benchee.Conversion.Format do
       "1 KB"
 
   """
-  def format({count, unit = %Unit{}}) do
-    format(count, label(unit), separator())
+  def format({number, unit = %Unit{}}) do
+    format(number, label(unit), separator())
   end
 
-  def format({count, unit = %Unit{}}, _module) do
-    format({count, unit})
+  def format({number, unit = %Unit{}}, _module) do
+    format({number, unit})
   end
 
-  def format({count, unit_atom}, module) do
-    format({count, module.unit_for(unit_atom)})
+  def format({number, unit_atom}, module) do
+    format({number, module.unit_for(unit_atom)})
   end
 
   def format(number, module) when is_number(number) do
@@ -96,9 +103,7 @@ defmodule Benchee.Conversion.Format do
   end
 
   defp units_descending(module) do
-    module.units()
-    |> Map.values()
-    |> Enum.sort(&(&1.magnitude >= &2.magnitude))
+    Enum.sort(module.units(), &(&1.magnitude >= &2.magnitude))
   end
 
   @spec place_values(number, [Unit.t()]) :: [{number, Unit.t()}]

--- a/lib/benchee/conversion/format.ex
+++ b/lib/benchee/conversion/format.ex
@@ -24,10 +24,14 @@ defmodule Benchee.Conversion.Format do
     "#{number_format(count)}#{separator}#{label}"
   end
 
-  defp number_format(count) do
+  defp number_format(count) when is_float(count) do
     count
     |> :erlang.float_to_list(decimals: float_precision(count))
     |> to_string
+  end
+
+  defp number_format(count) when is_integer(count) do
+    to_string(count)
   end
 
   @doc """
@@ -57,7 +61,7 @@ defmodule Benchee.Conversion.Format do
     format({count, module.unit_for(unit_atom)})
   end
 
-  def format(number, module) do
+  def format(number, module) when is_number(number) do
     number
     |> module.scale()
     |> format

--- a/lib/benchee/conversion/format.ex
+++ b/lib/benchee/conversion/format.ex
@@ -85,6 +85,10 @@ defmodule Benchee.Conversion.Format do
     format(0, module)
   end
 
+  def format_human(+0.0, module) do
+    format(0, module)
+  end
+
   def format_human(number, module) when is_number(number) do
     number
     |> split_into_place_values(module)
@@ -108,6 +112,7 @@ defmodule Benchee.Conversion.Format do
 
   @spec place_values(number, [Unit.t()]) :: [{number, Unit.t()}]
   defp place_values(0, _units), do: []
+  defp place_values(+0.0, _units), do: []
 
   # smalles unit, carries the decimal
   defp place_values(number, [base_unit = %Unit{magnitude: 1}]), do: [{number, base_unit}]

--- a/lib/benchee/conversion/format.ex
+++ b/lib/benchee/conversion/format.ex
@@ -88,7 +88,7 @@ defmodule Benchee.Conversion.Format do
   # The output is sorted descending by magnitude of units and excludes tuples with place value 0.
   # Place values are `non_neg_integer` for non-base units,
   # however base unit may also be `float` becuase the decimals can't be split further.
-  @spec split_into_place_values(number, module) :: [{number, Scale.unit()}]
+  @spec split_into_place_values(number, module) :: [{number, Unit.t()}]
   defp split_into_place_values(number, module) do
     descending_units = units_descending(module)
 
@@ -101,7 +101,7 @@ defmodule Benchee.Conversion.Format do
     |> Enum.sort(&(&1.magnitude >= &2.magnitude))
   end
 
-  @spec place_values(number, [Scale.unit()]) :: [{number, Scale.unit()}]
+  @spec place_values(number, [Unit.t()]) :: [{number, Unit.t()}]
   defp place_values(0, _units), do: []
 
   # smalles unit, carries the decimal

--- a/lib/benchee/conversion/memory.ex
+++ b/lib/benchee/conversion/memory.ex
@@ -15,7 +15,7 @@ defmodule Benchee.Conversion.Memory do
   @bytes_per_gigabyte @bytes_per_megabyte * @bytes_per_kilobyte
   @bytes_per_terabyte @bytes_per_gigabyte * @bytes_per_kilobyte
 
-  @units %{
+  @units_map %{
     terabyte: %Unit{
       name: :terabyte,
       magnitude: @bytes_per_terabyte,
@@ -47,6 +47,8 @@ defmodule Benchee.Conversion.Memory do
       long: "Bytes"
     }
   }
+
+  @units Map.values(@units_map)
 
   @type unit_atom :: :byte | :kilobyte | :megabyte | :gigabyte | :terabyte
   @type any_unit :: unit_atom | Unit.t()
@@ -162,7 +164,11 @@ defmodule Benchee.Conversion.Memory do
       }
   """
   def unit_for(unit) do
-    Scale.unit_for(@units, unit)
+    Scale.unit_for(@units_map, unit)
+  end
+
+  def units do
+    @units
   end
 
   @doc """
@@ -225,8 +231,9 @@ defmodule Benchee.Conversion.Memory do
   def base_unit, do: unit_for(:byte)
 
   @doc """
-  Formats a number as a string, with a unit label. To specify the unit, pass
-  a tuple of `{value, unit_atom}` like `{1_234, :kilobyte}`
+  Formats a memory as a string, with a unit label.
+
+  To specify the unit, pass a tuple of `{value, unit_atom}` like `{1_234, :kilobyte}`.
 
   ## Examples
 
@@ -248,5 +255,20 @@ defmodule Benchee.Conversion.Memory do
   """
   def format(memory) do
     Format.format(memory, __MODULE__)
+  end
+
+  @doc """
+  Formats in a more human way, where multiple units are used.
+
+  ## Examples
+
+      iex> format_human(45_678.9)
+      "44 KB 622.90 B"
+
+      iex> format_human(1024 * 1024 * 1024)
+      "1 GB"
+  """
+  def format_human(memory) do
+    Format.format_human(memory, __MODULE__)
   end
 end

--- a/lib/benchee/conversion/scale.ex
+++ b/lib/benchee/conversion/scale.ex
@@ -17,14 +17,14 @@ defmodule Benchee.Conversion.Scale do
   @doc """
   Scales a number in a domain's base unit to an equivalent value in the best
   fit unit. Results are a `{number, unit}` tuple. See `Benchee.Conversion.Count` and
-  `Benchee.Conversion.Duration` for examples
+  `Benchee.Conversion.Duration` for examples.
   """
   @callback scale(number) :: scaled_number
 
   @doc """
   Scales a number in a domain's base unit to an equivalent value in the
-  specified unit. Results are a `{number, unit}` tuple. See
-  `Benchee.Conversion.Count` and `Benchee.Conversion.Duration` for examples
+  specified unit.
+  See `Benchee.Conversion.Count` and `Benchee.Conversion.Duration` for examples.
   """
   @callback scale(number, any_unit) :: number
 

--- a/lib/benchee/conversion/scale.ex
+++ b/lib/benchee/conversion/scale.ex
@@ -48,6 +48,11 @@ defmodule Benchee.Conversion.Scale do
   @callback unit_for(any_unit) :: unit
 
   @doc """
+  List of all the units supported by this type.
+  """
+  @callback units :: [unit]
+
+  @doc """
   Takes a tuple of a number and a unit and a unit to be converted to, returning
   the the number scaled to the new unit and the new unit.
   """

--- a/lib/benchee/output/benchmark_printer.ex
+++ b/lib/benchee/output/benchmark_printer.ex
@@ -75,13 +75,13 @@ defmodule Benchee.Output.BenchmarkPrinter do
 
     IO.puts("""
     Benchmark suite executing with the following configuration:
-    warmup: #{Duration.format(warmup)}
-    time: #{Duration.format(time)}
-    memory time: #{Duration.format(memory_time)}
-    reduction time: #{Duration.format(reduction_time)}
+    warmup: #{Duration.format_verbose(warmup)}
+    time: #{Duration.format_verbose(time)}
+    memory time: #{Duration.format_verbose(memory_time)}
+    reduction time: #{Duration.format_verbose(reduction_time)}
     parallel: #{parallel}
     inputs: #{inputs_out(inputs)}
-    Estimated total run time: #{Duration.format(total_time)}
+    Estimated total run time: #{Duration.format_verbose(total_time)}
     """)
   end
 

--- a/lib/benchee/output/benchmark_printer.ex
+++ b/lib/benchee/output/benchmark_printer.ex
@@ -75,13 +75,13 @@ defmodule Benchee.Output.BenchmarkPrinter do
 
     IO.puts("""
     Benchmark suite executing with the following configuration:
-    warmup: #{Duration.format_verbose(warmup)}
-    time: #{Duration.format_verbose(time)}
-    memory time: #{Duration.format_verbose(memory_time)}
-    reduction time: #{Duration.format_verbose(reduction_time)}
+    warmup: #{Duration.format_human(warmup)}
+    time: #{Duration.format_human(time)}
+    memory time: #{Duration.format_human(memory_time)}
+    reduction time: #{Duration.format_human(reduction_time)}
     parallel: #{parallel}
     inputs: #{inputs_out(inputs)}
-    Estimated total run time: #{Duration.format_verbose(total_time)}
+    Estimated total run time: #{Duration.format_human(total_time)}
     """)
   end
 

--- a/test/benchee/conversion/duration_test.exs
+++ b/test/benchee/conversion/duration_test.exs
@@ -49,69 +49,69 @@ defmodule Benchee.Conversion.DurationTest do
     end
   end
 
-  describe ".format_verbose" do
-    test ".format_verbose(0)" do
-      assert format_verbose(0) == "0 ns"
+  describe ".format_human" do
+    test ".format_human(0)" do
+      assert format_human(0) == "0 ns"
     end
 
-    test ".format_verbose(0.00)" do
-      assert format_verbose(0.00) == "0 ns"
+    test ".format_human(0.00)" do
+      assert format_human(0.00) == "0 ns"
     end
 
-    test ".format_verbose(98.7654321)" do
-      assert format_verbose(98.7654321) == "98.77 ns"
+    test ".format_human(98.7654321)" do
+      assert format_human(98.7654321) == "98.77 ns"
     end
 
-    test ".format_verbose(523.0)" do
-      assert format_verbose(523.0) == "523 ns"
+    test ".format_human(523.0)" do
+      assert format_human(523.0) == "523 ns"
     end
 
-    test ".format_verbose(987.654321)" do
-      assert format_verbose(987.654321) == "987.65 ns"
+    test ".format_human(987.654321)" do
+      assert format_human(987.654321) == "987.65 ns"
     end
 
-    test ".format_verbose(9_008)" do
-      assert format_verbose(9_008) == "9 μs 8 ns"
+    test ".format_human(9_008)" do
+      assert format_human(9_008) == "9 μs 8 ns"
     end
 
-    test ".format_verbose(9_876.54321)" do
-      assert format_verbose(9_876.54321) == "9 μs 876.54 ns"
+    test ".format_human(9_876.54321)" do
+      assert format_human(9_876.54321) == "9 μs 876.54 ns"
     end
 
-    test ".format_verbose(98_765.4321)" do
-      assert format_verbose(98_765.4321) == "98 μs 765.43 ns"
+    test ".format_human(98_765.4321)" do
+      assert format_human(98_765.4321) == "98 μs 765.43 ns"
     end
 
-    test ".format_verbose(987_654.321)" do
-      assert format_verbose(987_654.321) == "987 μs 654.32 ns"
+    test ".format_human(987_654.321)" do
+      assert format_human(987_654.321) == "987 μs 654.32 ns"
     end
 
-    test ".format_verbose(9_008_000_000)" do
-      assert format_verbose(9_008_000_000) == "9 s 8 ms"
+    test ".format_human(9_008_000_000)" do
+      assert format_human(9_008_000_000) == "9 s 8 ms"
     end
 
-    test ".format_verbose(9_876_543_210)" do
-      assert format_verbose(9_876_543_210) == "9 s 876 ms 543 μs 210 ns"
+    test ".format_human(9_876_543_210)" do
+      assert format_human(9_876_543_210) == "9 s 876 ms 543 μs 210 ns"
     end
 
-    test ".format_verbose(90_000_000_000)" do
-      assert format_verbose(90_000_000_000) == "1 min 30 s"
+    test ".format_human(90_000_000_000)" do
+      assert format_human(90_000_000_000) == "1 min 30 s"
     end
 
-    test ".format_verbose(98_765_432_190)" do
-      assert format_verbose(98_765_432_190) == "1 min 38 s 765 ms 432 μs 190 ns"
+    test ".format_human(98_765_432_190)" do
+      assert format_human(98_765_432_190) == "1 min 38 s 765 ms 432 μs 190 ns"
     end
 
-    test ".format_verbose(987_654_321_987.6)" do
-      assert format_verbose(987_654_321_987.6) == "16 min 27 s 654 ms 321 μs 987.60 ns"
+    test ".format_human(987_654_321_987.6)" do
+      assert format_human(987_654_321_987.6) == "16 min 27 s 654 ms 321 μs 987.60 ns"
     end
 
-    test ".format_verbose(3_900_000_000_000)" do
-      assert format_verbose(3_900_000_000_000) == "1 h 5 min"
+    test ".format_human(3_900_000_000_000)" do
+      assert format_human(3_900_000_000_000) == "1 h 5 min"
     end
 
-    test ".format_verbose(9_876_543_219_876.5)" do
-      assert format_verbose(9_876_543_219_876.5) == "2 h 44 min 36 s 543 ms 219 μs 876.50 ns"
+    test ".format_human(9_876_543_219_876.5)" do
+      assert format_human(9_876_543_219_876.5) == "2 h 44 min 36 s 543 ms 219 μs 876.50 ns"
     end
   end
 

--- a/test/benchee/conversion/duration_test.exs
+++ b/test/benchee/conversion/duration_test.exs
@@ -74,6 +74,11 @@ defmodule Benchee.Conversion.DurationTest do
       assert format_human(9_008) == "9 μs 8 ns"
     end
 
+    # particularly nasty bug
+    test ".format_human()" do
+      assert format_human(2_000_000_000.0) == "2 s"
+    end
+
     test ".format_human(9_876.54321)" do
       assert format_human(9_876.54321) == "9 μs 876.54 ns"
     end

--- a/test/benchee/conversion/duration_test.exs
+++ b/test/benchee/conversion/duration_test.exs
@@ -24,19 +24,19 @@ defmodule Benchee.Conversion.DurationTest do
       assert format(987_654.321) == "987.65 μs"
     end
 
-    test ".format(9_876_543210)" do
+    test ".format(9_876_543_210)" do
       assert format(9_876_543_210) == "9.88 s"
     end
 
-    test ".format(98_765_432190)" do
+    test ".format(98_765_432_190)" do
       assert format(98_765_432_190) == "1.65 min"
     end
 
-    test ".format(987_654_321987.6)" do
+    test ".format(987_654_321_987.6)" do
       assert format(987_654_321_987.6) == "16.46 min"
     end
 
-    test ".format(9_876_543_219876.5)" do
+    test ".format(9_876_543_219_876.5)" do
       assert format(9_876_543_219_876.5) == "2.74 h"
     end
 
@@ -46,6 +46,72 @@ defmodule Benchee.Conversion.DurationTest do
 
     test ".format(0)" do
       assert format(0) == "0 ns"
+    end
+  end
+
+  describe ".format_verbose" do
+    test ".format_verbose(0)" do
+      assert format_verbose(0) == "0 ns"
+    end
+
+    test ".format_verbose(0.00)" do
+      assert format_verbose(0.00) == "0 ns"
+    end
+
+    test ".format_verbose(98.7654321)" do
+      assert format_verbose(98.7654321) == "98.77 ns"
+    end
+
+    test ".format_verbose(523.0)" do
+      assert format_verbose(523.0) == "523 ns"
+    end
+
+    test ".format_verbose(987.654321)" do
+      assert format_verbose(987.654321) == "987.65 ns"
+    end
+
+    test ".format_verbose(9_008)" do
+      assert format_verbose(9_008) == "9 μs 8 ns"
+    end
+
+    test ".format_verbose(9_876.54321)" do
+      assert format_verbose(9_876.54321) == "9 μs 876.54 ns"
+    end
+
+    test ".format_verbose(98_765.4321)" do
+      assert format_verbose(98_765.4321) == "98 μs 765.43 ns"
+    end
+
+    test ".format_verbose(987_654.321)" do
+      assert format_verbose(987_654.321) == "987 μs 654.32 ns"
+    end
+
+    test ".format_verbose(9_008_000_000)" do
+      assert format_verbose(9_008_000_000) == "9 s 8 ms"
+    end
+
+    test ".format_verbose(9_876_543_210)" do
+      assert format_verbose(9_876_543_210) == "9 s 876 ms 543 μs 210 ns"
+    end
+
+    test ".format_verbose(90_000_000_000)" do
+      assert format_verbose(90_000_000_000) == "1 min 30 s"
+    end
+
+    test ".format_verbose(98_765_432_190)" do
+      assert format_verbose(98_765_432_190) == "1 min 38 s 765 ms 432 μs 190 ns"
+    end
+
+    test ".format_verbose(987_654_321_987.6)" do
+      assert format_verbose(987_654_321_987.6) == "16 min 27 s 654 ms 321 μs 987.60 ns"
+    end
+
+    test ".format_verbose(3_900_000_000_000)" do
+      assert format_verbose(3_900_000_000_000) == "1 h 5 min"
+    end
+
+    test ".format_verbose(9_876_543_219_876.5)" do
+      assert format_verbose(9_876_543_219_876.5) == "2 h 44 min 36 s 543 ms 219 μs 876.50 ns"
     end
   end
 

--- a/test/benchee/output/benchmark_printer_test.exs
+++ b/test/benchee/output/benchmark_printer_test.exs
@@ -74,7 +74,7 @@ defmodule Benchee.Output.BenchmarkPrintertest do
       assert output =~ "time: 1 min"
       assert output =~ "memory time: 5 s"
       assert output =~ "parallel: 1"
-      assert output =~ "Estimated total run time: 2.50 min"
+      assert output =~ "Estimated total run time: 2 min 30 s"
     end
 
     @inputs %{"Arg 1" => 1, "Arg 2" => 2}


### PR DESCRIPTION
This is #373 - as I didn't take care of it for too long/forever I'm integrating it myself and polishing it up.


* [x] Implement it for the other units where suitable as well
* [x] see if we can make the `units()` or something nicer

Follow ups:
* [ ] make 0 format to "0 s" aka a destined better "human" base unit
* [ ] see about removing the space so "3h" instead of "3 h", ref: https://github.com/bencheeorg/benchee/pull/373#issuecomment-1353893220