### PR TITLE
Added initial Solaris support to Benchee.System

### DIFF
--- a/test/benchee/system_test.exs
+++ b/test/benchee/system_test.exs
@@ -74,6 +74,20 @@ defmodule Benchee.SystemTest do
       output = parse_cpu_for(:Linux, raw_output)
       assert output == "Unrecognized processor"
     end
+
+    @solaris_kstat_brand_excerpt """
+    cpu_info:0:cpu_info0:brand      Intel(r) Xeon(r) CPU E5-2678 v3 @ 2.50GHz
+    """
+    test "for :Solaris handles some normal intel output" do
+      output = parse_cpu_for(:Solaris, @solaris_kstat_brand_excerpt)
+      assert output =~ "Intel(r) Xeon(r) CPU E5-2678 v3 @ 2.50GHz"
+    end
+
+    test "for :Solaris handles unknown architectures" do
+      raw_output = "Bender Bending Rodriguez"
+      output = parse_cpu_for(:Solaris, raw_output)
+      assert output == "Unrecognized processor"
+    end
   end
 
   test ".available_memory returns the available memory on the computer" do

--- a/test/benchee/system_test.exs
+++ b/test/benchee/system_test.exs
@@ -39,7 +39,10 @@ defmodule Benchee.SystemTest do
   end
 
   test ".os returns an atom of the current os" do
-    assert Enum.member?([:Linux, :Solaris, :FreeBSD, :macOS, :Windows], system(%Suite{}).system.os)
+    assert Enum.member?(
+             [:Linux, :Solaris, :FreeBSD, :macOS, :Windows],
+             system(%Suite{}).system.os
+           )
   end
 
   test ".cpu_speed returns a string (more accurate tests in .parse_cpu_for)" do

--- a/test/benchee/system_test.exs
+++ b/test/benchee/system_test.exs
@@ -39,7 +39,7 @@ defmodule Benchee.SystemTest do
   end
 
   test ".os returns an atom of the current os" do
-    assert Enum.member?([:Linux, :FreeBSD, :macOS, :Windows], system(%Suite{}).system.os)
+    assert Enum.member?([:Linux, :Solaris, :FreeBSD, :macOS, :Windows], system(%Suite{}).system.os)
   end
 
   test ".cpu_speed returns a string (more accurate tests in .parse_cpu_for)" do


### PR DESCRIPTION
Associated PR for issue: https://github.com/bencheeorg/benchee/issues/421
Added calls as appropriate to kstat and prtconf to produce intended results.

This was specifically tested on SmartOS base-64-trunk 20231113