### PR TITLE
Fix another deprecation warning on missing parenthesis

### DIFF
--- a/lib/benchee/conversion/scale.ex
+++ b/lib/benchee/conversion/scale.ex
@@ -175,7 +175,7 @@ defmodule Benchee.Conversion.Scale do
       :best -> best_unit(list, module)
       :largest -> largest_unit(list, module)
       :smallest -> smallest_unit(list, module)
-      :none -> module.base_unit
+      :none -> module.base_unit()
     end
   end
 


### PR DESCRIPTION
Hi!

This the same fix as https://github.com/bencheeorg/benchee/commit/2d56fba7e9df361943e1342889c816cc2c6056f4.

It fixes the following warning:

```elixir
warning: using map.field notation (without parentheses) to invoke function Benchee.Conversion.Count.base_unit() is deprecated, you must add parentheses instead: remote.function()
  (benchee 1.2.0) lib/benchee/conversion/scale.ex:165: Benchee.Conversion.Scale.do_best_unit/3
  (benchee 1.2.0) lib/benchee/conversion.ex:63: Benchee.Conversion.units/2
...
````

I think there is no occurrence left.

Cheers!