### PR TITLE
Make when to run lint/dialyzer more flexible

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,8 @@ jobs:
             otp_version: '26.2'
           - elixir_version: '1.18'
             otp_version: '27.3'
+            type_check: true
+            lint: true
 
     steps:
       - name: Checkout
@@ -66,26 +68,27 @@ jobs:
         with:
           path: tools/plts
           key: erlef-${{ runner.os }}-dialyzer-${{ matrix.elixir_version }}-${{ matrix.otp_version }}-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
-        if: contains(matrix.elixir_version, '1.18')
+        if: ${{ matrix.type_check }}
       - run: mix deps.get
       - run: MIX_ENV=test mix compile --warnings-as-errors
       - run: mix credo
-        if: contains(matrix.elixir_version, '1.18')
+        if: ${{ matrix.lint }}
       - name: Check if formatted
-        if: contains(matrix.elixir_version, '1.18')
+        if: ${{ matrix.lint }}
         run: mix format --check-formatted
       - name: Actual Tests
         # this will let warnings slip through but I don't wanna replicate all that magic
         # right now
         run: MIX_ENV=test mix coveralls.github || mix test --failed
         # Apparently the one with `!` can't go without the fancy expression syntax
-        if: ${{ !contains(matrix.elixir_version, '1.18') }}
+        if: ${{ !matrix.lint }}
+        # warnings as errors is a form of linting!
       - name: Actual Tests WITH warnings as errors
         run: MIX_ENV=test mix coveralls.github --warnings-as-errors || mix test --failed
-        if: contains(matrix.elixir_version, '1.18')
+        if: ${{ matrix.lint }}
       - name: Dialyzer
         run: mix dialyzer --halt-exit-status
-        if: contains(matrix.elixir_version, '1.18')
+        if: ${{ matrix.type_check }}
 
   macos:
     name: Test on MacOS


### PR DESCRIPTION
Removes the duplication on the elixir versions that was error prone and needed updating.

Also would allow us to run it on more versions.

With friendly inspiration from mint:
https://github.com/elixir-mint/mint/blob/90ee9fdb27c0d52b374b8d689c54d8559b2bb57c/.github/workflows/main.yml