### PR TITLE
gitignore .tool-versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,11 @@ benchee-*.tar
 # Temporary files for e.g. tests.
 /tmp/
 
+# Kinda changed my opinion on this, it became annoying to upgrade patch versions on my other
+# systems just to be in sync. Since this is a library that should work on _many_ versions and
+# runs CI that way there is no need for strict enforcement.
+.tool-versions
+
 # Misc.
 save.benchee
 /test/tmp/

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,0 @@
-elixir 1.18.1-otp-27
-erlang 27.2


### PR DESCRIPTION
Kinda changed my opinion on this, it became annoying to upgrade patch versions on my other systems just to be in sync. Since this is a library that should work on _many_ versions and runs CI that way there is no need for strict enforcement.