### PR TITLE
Get back to current working path after test finishes

### DIFF
--- a/test/benchee_test.exs
+++ b/test/benchee_test.exs
@@ -1068,6 +1068,7 @@ defmodule BencheeTest do
   end
 
   describe "escript building" do
+    @working_directory File.cwd!()
     @sample_project_directory Path.expand("fixtures/escript", __DIR__)
     test "benchee can be built into and used as an escript" do
       File.cd!(@sample_project_directory)
@@ -1076,6 +1077,8 @@ defmodule BencheeTest do
 
       readme_sample_asserts(output)
       assert exit_status == 0
+    after
+      File.cd!(@working_directory)
     end
   end
 


### PR DESCRIPTION
The escript building test didn't use to restore the proper working directory. This caused `mix coveralls.html` not to work as it got confused looking up the html template to render in the dependencies.